### PR TITLE
Added method to find DIABDAT.MPQ case insensitive

### DIFF
--- a/components/faio/faio.h
+++ b/components/faio/faio.h
@@ -51,6 +51,7 @@ namespace FAIO
     uint16_t read16(FAFile* file);
     uint8_t read8(FAFile* file);
     std::string readCString(FAFile* file, size_t ptr);
+    std::string getMPQFileName();
 }
 
 #endif 


### PR DESCRIPTION
Let me know if this is a useful change and what coding style you prefer.

OT: I found that after the diablo installation my diabdat.mpq file was lower case and i had to rename it to upper case. for that matter i changed the code so that it finds and loads the file regardless of case.
