### PR TITLE
Made NPCs moddable

### DIFF
--- a/resources/NPCs.ini
+++ b/resources/NPCs.ini
@@ -1,0 +1,6 @@
+#[NPCBard]
+#name=Bard
+#cel=towners/bard/blsst.cl2
+#x=32
+#y=42
+#r=0


### PR DESCRIPTION
Me and qualakon made this modification which allows moddable NPCs to be included in Freeablo through /resources/NPCs.ini. We have tested this and it works. Included in NPCs.ini is a commented out example of how a custom NPC would be set up.
