### PR TITLE
Fixed crash on exit when DIABDAT.MPQ cannot be opened

### DIFF
--- a/components/faio/faio.cpp
+++ b/components/faio/faio.cpp
@@ -52,7 +52,10 @@ namespace FAIO
 
     void quit()
     {
-        SFileCloseArchive(diabdat);
+        if (NULL != diabdat)
+        {
+            SFileCloseArchive(diabdat);
+        }
     }
 
     FAFile* FAfopen(const std::string& filename)


### PR DESCRIPTION
When DIABDAT.MPQ cannot be opened the game crashes inside SFileCloseArchive() function as it doesn't check the argument for NULL pointer.