### PR TITLE
Loading and rendering original Diablo-fonts

### DIFF
--- a/apps/freeablo/CMakeLists.txt
+++ b/apps/freeablo/CMakeLists.txt
@@ -33,6 +33,10 @@ add_executable(freeablo
     fagui/animateddecorator.cpp
     fagui/animateddecoratorinstancer.h
     fagui/animateddecoratorinstancer.cpp
+    fagui/textdecorator.h
+    fagui/textdecorator.cpp
+    fagui/textdecoratorinstancer.h
+    fagui/textdecoratorinstancer.cpp
 
     engine/threadmanager.h
     engine/threadmanager.cpp

--- a/apps/freeablo/fagui/guimanager.cpp
+++ b/apps/freeablo/fagui/guimanager.cpp
@@ -5,6 +5,7 @@
 #include <misc/enablewarn.h>
 
 #include "animateddecoratorinstancer.h"
+#include "textdecoratorinstancer.h"
 
 #include "../farender/renderer.h"
 
@@ -57,6 +58,9 @@ namespace FAGui
 
         Rocket::Core::DecoratorInstancer* animInstancer = Rocket::Core::Factory::RegisterDecoratorInstancer("faanim", (Rocket::Core::DecoratorInstancer*)new AnimatedDecoratorInstancer(renderer->getRocketContext()->GetRenderInterface()));
         animInstancer->RemoveReference();
+
+        Rocket::Core::DecoratorInstancer* textInstancer = Rocket::Core::Factory::RegisterDecoratorInstancer("fatext", (Rocket::Core::DecoratorInstancer*)new TextDecoratorInstancer(renderer->getRocketContext()->GetRenderInterface()));
+        textInstancer->RemoveReference();
 
         ingameUi = renderer->getRocketContext()->LoadDocument("resources/gui/base.rml");
         mainMenu = renderer->getRocketContext()->LoadDocument("resources/gui/mainmenu.rml");

--- a/apps/freeablo/fagui/textdecorator.cpp
+++ b/apps/freeablo/fagui/textdecorator.cpp
@@ -1,0 +1,179 @@
+#include "textdecorator.h"
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include <cmath>
+
+#include <render/render.h>
+#include <misc/misc.h>
+#include <faio/faio.h>
+
+namespace FAGui
+{
+    bool TextDecorator::mIsReady = false;
+    std::map<int, TextDecorator::Font> TextDecorator::mFonts;
+    std::vector<int> TextDecorator::mSpacebarSize;
+
+    void TextDecorator::init(Rocket::Core::RenderInterface* renderInterface)
+    {
+        // Load fonts
+        std::vector<std::string> fonts;
+        fonts.push_back("ui_art/font16g.pcx&trans=0,255,0&vanim=16");
+        fonts.push_back("ui_art/font24g.pcx&trans=0,255,0&vanim=26");
+        fonts.push_back("ui_art/font30g.pcx&trans=0,255,0&vanim=31");
+        fonts.push_back("ui_art/font42g.pcx&trans=0,255,0&vanim=42");
+
+        std::vector<std::string> fontsGray;
+        fontsGray.push_back("ui_art/font16s.pcx&trans=0,255,0&vanim=16");
+        fontsGray.push_back("ui_art/font24s.pcx&trans=0,255,0&vanim=26");
+        fontsGray.push_back("ui_art/font30s.pcx&trans=0,255,0&vanim=31");
+        fontsGray.push_back("ui_art/font42y.pcx&trans=0,255,0&vanim=42");
+
+        std::vector<std::string> fontsBinaryFiles;
+        fontsBinaryFiles.push_back("ui_art/font16.bin");
+        fontsBinaryFiles.push_back("ui_art/font24.bin");
+        fontsBinaryFiles.push_back("ui_art/font30.bin");
+        fontsBinaryFiles.push_back("ui_art/font42.bin");
+
+        std::vector<int> fontsSize;
+        fontsSize.push_back(16);
+        fontsSize.push_back(24);
+        fontsSize.push_back(30);
+        fontsSize.push_back(42);
+
+        mSpacebarSize.push_back(10);
+        mSpacebarSize.push_back(16);
+        mSpacebarSize.push_back(20);
+        mSpacebarSize.push_back(26);
+
+        for(int i = 0 ; i < (int)fonts.size(); i++)
+        {
+            int frame0Index = LoadTexture(fonts[i].c_str(), "");
+            Render::RocketFATex* texture = (Render::RocketFATex*)GetTexture(frame0Index)->GetHandle(renderInterface);
+
+            Font font;
+            for(size_t k = 0; k < texture->animLength; k++)
+            {
+                std::ostringstream ss;
+                ss << fonts[i] << "&frame=" << k;
+                font.mFrames.push_back(LoadTexture(ss.str().c_str(), ""));
+
+                // Gray version
+                ss.str("");
+                ss << fontsGray[i] << "&frame=" << k;
+                font.mFramesGray.push_back(LoadTexture(ss.str().c_str(), ""));
+            }
+
+            //Read binary file with widths of letters
+
+            FAIO::FAFile * binaryFile = FAIO::FAfopen(fontsBinaryFiles[i]);
+            size_t size = FAIO::FAsize(binaryFile);
+            for(unsigned int k = 0 ; k < size ; ++k)
+            {
+                FAIO::FAfread(&font.mFontSize[k], 1, 1, binaryFile);
+            }
+            FAIO::FAfclose(binaryFile);
+
+            // Dirty hack for size of spacebar
+            font.mFontSize[' ' + 2] = mSpacebarSize[i];
+
+
+            mFonts[fontsSize[i]] = font;
+        }
+
+        mIsReady = true;
+    }
+
+    TextDecorator::TextDecorator(Rocket::Core::RenderInterface* renderInterface, const std::string& text, int size, const std::string& style) : Rocket::Core::Decorator(),
+        mText(text),
+        mSize(size)
+    {
+        if(!mIsReady)
+            init(renderInterface);
+
+        if(style == "gray")
+            mStyle = GRAY;
+        else
+            mStyle = NORMAL;
+
+        // validate size
+        if(size != SIZE_16 &&
+           size != SIZE_24 &&
+           size != SIZE_30 &&
+           size != SIZE_42)
+        {
+            std::cout << "Wrong font size: " << size << " for text: " << text << std::endl;
+            return;
+        }
+
+        int frame0Index = mFonts[size].mFrames[0];
+
+        // set up vertices
+        std::vector<Rocket::Core::Vertex>& vertices = mGeometry.GetVertices();
+        std::vector<int>& indices = mGeometry.GetIndices();
+
+        mTexDimensions = GetTexture(frame0Index)->GetDimensions(renderInterface);
+
+        Rocket::Core::Vertex vertex;
+        vertex.colour = Rocket::Core::Colourb(255, 255, 255, 255);
+
+        vertex.position = Rocket::Core::Vector2f(0, 0);
+        vertex.tex_coord = Rocket::Core::Vector2f(0, 0);
+        vertices.push_back(vertex);
+        vertex.position = Rocket::Core::Vector2f(0, mTexDimensions.y);
+        vertex.tex_coord = Rocket::Core::Vector2f(0, 1);
+        vertices.push_back(vertex);
+        vertex.position = Rocket::Core::Vector2f(mTexDimensions.x, mTexDimensions.y);
+        vertex.tex_coord = Rocket::Core::Vector2f(1, 1);
+        vertices.push_back(vertex);
+        vertex.position = Rocket::Core::Vector2f(mTexDimensions.x, 0);
+        vertex.tex_coord = Rocket::Core::Vector2f(1, 0);
+        vertices.push_back(vertex);
+
+        indices.push_back(0);
+        indices.push_back(1);
+        indices.push_back(2);
+        indices.push_back(0);
+        indices.push_back(2);
+        indices.push_back(3);
+    }
+
+    Rocket::Core::DecoratorDataHandle TextDecorator::GenerateElementData(Rocket::Core::Element* element)
+    {
+        UNUSED_PARAM(element);
+        return (Rocket::Core::DecoratorDataHandle)NULL;
+    }
+
+    void TextDecorator::ReleaseElementData(Rocket::Core::DecoratorDataHandle element_data)
+    {
+        UNUSED_PARAM(element_data);
+    }
+
+    void TextDecorator::RenderElement(Rocket::Core::Element* element, Rocket::Core::DecoratorDataHandle element_data)
+    {
+        UNUSED_PARAM(element_data);
+
+        int textLength = mText.size();
+        float offset = 0.0f;
+
+        for(int i = 0 ; i < textLength ; i++)
+        {
+            int currentFrame = mText[i];
+            const Rocket::Core::Texture* tex;
+
+            if(mStyle == GRAY)
+                tex = GetTexture(mFonts[mSize].mFramesGray[currentFrame]);
+            else
+                tex = GetTexture(mFonts[mSize].mFrames[currentFrame]);
+
+            Rocket::Core::Vector2f absoluteOffsetVector = element->GetAbsoluteOffset(Rocket::Core::Box::PADDING);
+            Rocket::Core::Vector2f position = Rocket::Core::Vector2f(absoluteOffsetVector.x + offset,absoluteOffsetVector.y);
+            mGeometry.SetTexture(tex);
+            mGeometry.Render(position);
+
+            offset += mFonts[mSize].mFontSize[currentFrame + 2];
+
+        }
+    }
+}

--- a/apps/freeablo/fagui/textdecorator.h
+++ b/apps/freeablo/fagui/textdecorator.h
@@ -1,0 +1,59 @@
+#ifndef TEXT_DECORATOR_H
+#define TEXT_DECORATOR_H
+
+#include <Rocket/Core.h>
+
+#include <vector>
+#include <map>
+
+namespace FAGui
+{
+    class TextDecorator : Rocket::Core::Decorator
+    {
+        public:
+            TextDecorator(Rocket::Core::RenderInterface* renderInterface, const std::string& text, int size, const std::string& style);
+
+        private:
+            struct Font
+            {
+                uint8_t mFontSize[300];
+                std::vector<int> mFrames;
+                std::vector<int> mFramesGray;
+            };
+
+            enum FontSize
+            {
+                SIZE_16 = 16,
+                SIZE_24 = 24,
+                SIZE_30 = 30,
+                SIZE_42 = 42
+
+            };
+
+            enum FontStyle
+            {
+                NORMAL,
+                GRAY
+            };
+
+        private:
+            virtual Rocket::Core::DecoratorDataHandle GenerateElementData(Rocket::Core::Element* element);
+            virtual void ReleaseElementData(Rocket::Core::DecoratorDataHandle element_data);
+            virtual void RenderElement(Rocket::Core::Element* element, Rocket::Core::DecoratorDataHandle element_data);
+
+            std::string mText;
+            int mSize;
+            FontStyle mStyle;
+
+            void init(Rocket::Core::RenderInterface* renderInterface);
+            static bool mIsReady;
+            static std::map<int, Font > mFonts;
+            static std::vector<int> mSpacebarSize;
+
+            Rocket::Core::Geometry mGeometry;
+            Rocket::Core::Vector2i mTexDimensions;
+
+    };
+}
+
+#endif

--- a/apps/freeablo/fagui/textdecoratorinstancer.cpp
+++ b/apps/freeablo/fagui/textdecoratorinstancer.cpp
@@ -1,0 +1,38 @@
+#include "textdecoratorinstancer.h"
+
+#include "textdecorator.h"
+
+#include <misc/misc.h>
+
+namespace FAGui
+{
+    TextDecoratorInstancer::TextDecoratorInstancer(Rocket::Core::RenderInterface* renderInterface)
+    {
+        mRenderInterface = renderInterface;
+
+        RegisterProperty("style", "normal").AddParser("string");
+        RegisterProperty("size", "42").AddParser("number");
+        RegisterProperty("text", "TEST").AddParser("string");
+    }
+
+    Rocket::Core::Decorator* TextDecoratorInstancer::InstanceDecorator(const Rocket::Core::String& name, const Rocket::Core::PropertyDictionary& properties)
+    {
+        UNUSED_PARAM(name);
+
+        std::string text = std::string(properties.GetProperty("text")->Get<Rocket::Core::String>().CString());
+        std::string style = std::string(properties.GetProperty("style")->Get<Rocket::Core::String>().CString());
+        int size = properties.GetProperty("size")->Get<int>();
+
+        return (Rocket::Core::Decorator*)new TextDecorator(mRenderInterface, text, size, style);
+    }
+
+    void TextDecoratorInstancer::ReleaseDecorator(Rocket::Core::Decorator* decorator)
+    {
+        delete decorator;
+    }
+
+    void TextDecoratorInstancer::Release()
+    {
+        delete this;
+    }
+}

--- a/apps/freeablo/fagui/textdecoratorinstancer.h
+++ b/apps/freeablo/fagui/textdecoratorinstancer.h
@@ -1,0 +1,22 @@
+#ifndef TEXT_DECORATOR_INSTANCER_H
+#define TEXT_DECORATOR_INSTANCER_H
+
+#include <Rocket/Core.h>
+
+namespace FAGui
+{
+    class TextDecoratorInstancer : Rocket::Core::DecoratorInstancer
+    {
+        public:
+            TextDecoratorInstancer(Rocket::Core::RenderInterface* renderInterface);
+
+        private:
+            virtual Rocket::Core::Decorator* InstanceDecorator(const Rocket::Core::String& name, const Rocket::Core::PropertyDictionary& properties);
+            virtual void ReleaseDecorator(Rocket::Core::Decorator* decorator);
+            virtual void Release();
+
+            Rocket::Core::RenderInterface* mRenderInterface;
+    };
+}
+
+#endif

--- a/resources/gui/mainmenu.rml
+++ b/resources/gui/mainmenu.rml
@@ -46,6 +46,16 @@
                 height: 48px;
             }
 
+            div#version
+            {
+                icon-decorator: fatext;
+                icon-text: Freeablo v1.0;
+                icon-size: 24;
+                icon-style: gray;
+
+                margin-left: -500px;
+            }
+
             span#mainmenulogo
             {
                 width: 640px;
@@ -97,6 +107,9 @@ def onKeyDown(event, document):
                 <span id="smlogo"></span> <br/>
                 
                 <div id="innerMenuContainer"></div> 
+                <br/>
+                <br/>
+                <div id="version"></div>
             </div>
         </div>
     </body>

--- a/resources/gui/mainmenu.rml
+++ b/resources/gui/mainmenu.rml
@@ -46,6 +46,18 @@
                 height: 48px;
             }
 
+            span#mainmenulogo
+            {
+                width: 640px;
+                height: 480px;
+                background-decorator: image;
+                background-image: /ui_art/mainmenu.pcx;
+                position: absolute;
+                margin-top: -200px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+
         </style>
 
         <script>
@@ -80,6 +92,7 @@ def onKeyDown(event, document):
 
     <body onkeydown="onKeyDown(event, document)" onload="onLoad(document)">
         <div id="topContainer">
+            <span id="mainmenulogo"></span>
             <div id="menuContainer">
                 <span id="smlogo"></span> <br/>
                 


### PR DESCRIPTION
Hi, i added two things: 
1. Image in background in main menu
2. Loading and rendering original Diablo-fonts from MPQ. 

Example in RML: 
            div#version
            {
                icon-decorator: fatext;
                icon-text: Freeablo v1.0;
                icon-size: 24;    // available 16,24,30 and 42
                icon-style: gray;   // available: gray or normal font
            }

I had no time to reimplement main menu, just added game version at the bottom.