### PR TITLE
Minor fix for audio

### DIFF
--- a/apps/freeablo/faaudio/audiomanager.cpp
+++ b/apps/freeablo/faaudio/audiomanager.cpp
@@ -76,7 +76,8 @@ namespace FAAudio
         }
 
         int channel = Audio::playSound(mCache[path].sound);
-        mPlaying[channel] = path;
+        if(channel >= 0)
+            mPlaying[channel] = path;
     }
 
     void AudioManager::playMusic(const std::string& path)


### PR DESCRIPTION
On my env without enabled sounds freeablo crashes because Audio::playSound always returns -1.