### PR TITLE
Workaround for libRocket's lack of support for inline "background-image"

### DIFF
--- a/components/level/item.cpp
+++ b/components/level/item.cpp
@@ -1,8 +1,6 @@
 #include "item.h"
-#include "../apps/freeablo/faworld/inventory.h"
 #include "itemmanager.h"
 namespace Level
-
 {
 Item::Item()
 {

--- a/components/level/item.h
+++ b/components/level/item.h
@@ -10,10 +10,9 @@ namespace FAWorld
 {
 class Inventory;
 }
+
 namespace Level
 {
-
-
 
 class ItemPosition;
 class Item

--- a/components/level/item.h
+++ b/components/level/item.h
@@ -2,7 +2,9 @@
 #define ITEM_H
 #include <diabloexe/baseitem.h>
 #include <diabloexe/prefix.h>
-#include <render/render.h>
+#include <cel/celfile.h>
+#include <cel/celframe.h>
+
 
 namespace FAWorld
 {

--- a/components/level/itemmanager.cpp
+++ b/components/level/itemmanager.cpp
@@ -36,16 +36,11 @@ void ItemManager::loadItems(DiabloExe::DiabloExe * exe)
     }
 }
 
-void ItemManager::addItem(Item &item,
-                          Item::equipLoc invType,
-                          std::pair<size_t,size_t> * floorPosition,
-                          std::pair<uint8_t, uint8_t> * invPosition,
-                          uint8_t beltPosition,
-                          uint32_t count)
+void ItemManager::addItem(Item &item, std::pair<size_t, size_t> floorPosition, uint32_t count)
 {
     item.setCount(count);
-    ItemPosition temp =ItemPosition(invType, floorPosition, invPosition, beltPosition);
-    this->mItemPositionMap[temp]=item;
+    ItemPosition temp = ItemPosition(floorPosition);
+    mItemPositionMap[temp]=item;
 
     return;
 
@@ -89,12 +84,7 @@ Item ItemManager::getBaseItem(uint8_t id) const
     search.setUniqueId(uniqueId);
     return search;
 }
-void ItemManager::putItem(Item item,
-                          Item::equipLoc to,
-                          Item::equipLoc from,
-                          std::pair<uint8_t, uint8_t> * invPosition,
-                          uint8_t beltX,
-                          std::pair<size_t, size_t> * floorPosition)
+void ItemManager::putItemOnFloor(Item& item, std::pair<size_t, size_t> floor_pos)
 {
 
     std::map<ItemPosition, Item>::const_iterator it = std::find_if(
@@ -103,57 +93,20 @@ void ItemManager::putItem(Item item,
                 boost::bind(&std::map<ItemPosition, Item>::value_type::second, _1) == item
                 );
     ItemPosition pos = it->first;
-    if(it== mItemPositionMap.end())
-    switch(from)
+    if(it != mItemPositionMap.end())
     {
-    case Item::eqINV:
-        if(to == Item::eqFLOOR)
-        {
-            pos.setFloorPosition(floorPosition);
-            pos.setInventoryType(Item::eqFLOOR);
-        }
-        break;
-    case Item::eqFLOOR:
-        pos.setInvPosition(invPosition);
-        pos.setInventoryType(to);
-        break;
-    case Item::eqBELT:
-        pos.setInventoryType(to);
-        pos.setBeltPosition(beltX);
-        break;
-    case Item::eqBODY:
-
-        pos.setInventoryType(to);
-        break;
-    case Item::eqRIGHTHAND:
-
-        pos.setInventoryType(to);
-        break;
-    case Item::eqLEFTHAND:
-
-        pos.setInventoryType(to);
-        break;
-    case Item::eqRIGHTRING:
-
-        pos.setInventoryType(to);
-        break;
-    case Item::eqAMULET:
-
-        pos.setInventoryType(to);
-        break;
-
-        break;
-    case Item::eqCURSOR:
-
-        pos.setInventoryType(to);
-        break;
-
-    case Item::eqRING:
-    case Item::eqONEHAND:
-    case Item::eqTWOHAND:
-    default:
-        return;
+        pos.setFloorPosition(floor_pos);
     }
+    else
+    {
+        ItemPosition new_pos;
+        new_pos.setFloorPosition(floor_pos);
+        mItemPositionMap[new_pos] = item;
+
+    }
+    return;
+
+
 
 
 }
@@ -178,58 +131,22 @@ void ItemManager::removeItem(Item item)
 
 }
 
-Item::equipLoc ItemPosition::getInventoryType() const
-{
-    return this->mInventoryType;
 
-}
-
-void ItemPosition::setInventoryType(Item::equipLoc type)
-{
-    this->mInventoryType=type;
-}
-
-std::pair<size_t,size_t> * ItemPosition::getFloorPosition() const
+std::pair<size_t,size_t> ItemPosition::getFloorPosition() const
 {
     return this->mFloorPosition;
 
 }
 
-void ItemPosition::setFloorPosition(std::pair<size_t,size_t> * pos)
+void ItemPosition::setFloorPosition(std::pair<size_t,size_t> pos)
 {
     this->mFloorPosition = pos;
 }
 
-std::pair<uint8_t, uint8_t> * ItemPosition::getInvPosition() const
-{
-    return this->mInvPosition;
-}
 
-void ItemPosition::setInvPosition(std::pair<uint8_t, uint8_t> * pos)
+ItemPosition::ItemPosition(std::pair<size_t,size_t> floorPosition)
 {
-    this->mInvPosition = pos;;
-}
-
-uint8_t ItemPosition::getBeltPosition() const
-{
-    return this->mBeltPosition;
-}
-
-void ItemPosition::setBeltPosition(uint8_t x)
-{
-    this->mBeltPosition = x;
-}
-
-ItemPosition::ItemPosition(Item::equipLoc invType,
-                           std::pair<size_t,size_t> * floorPosition,
-                           std::pair<uint8_t, uint8_t> * invPosition,
-                           uint8_t beltPosition)
-{
-    this->mInventoryType = invType;
     this->mFloorPosition = floorPosition;
-    this->mInvPosition = invPosition;
-    this->mBeltPosition = beltPosition;
-
 }
 
 bool ItemPosition::operator<(const ItemPosition rhs) const
@@ -240,9 +157,7 @@ bool ItemPosition::operator<(const ItemPosition rhs) const
 
 bool ItemPosition::operator ==(const ItemPosition rhs) const
 {
-    if(mInventoryType != rhs.mInventoryType)
-        return false;
-    if((mInvPosition != rhs.mInvPosition) || (mFloorPosition != rhs.mFloorPosition) || (mBeltPosition != rhs.mBeltPosition))
+    if(mFloorPosition != rhs.mFloorPosition)
         return false;
 
     return true;

--- a/components/level/itemmanager.h
+++ b/components/level/itemmanager.h
@@ -4,7 +4,6 @@
 #include "item.h"
 #include <map>
 #include <stdint.h>
-#include <boost/tuple/tuple.hpp>
 #include <diabloexe/diabloexe.h>
 namespace Level
 {
@@ -12,42 +11,27 @@ namespace Level
     class ItemPosition
     {
     public:
-        ItemPosition(Item::equipLoc invType,
-                     std::pair<size_t,size_t> *floorPosition,
-                     std::pair<uint8_t, uint8_t> *invPosition,
-                     uint8_t beltPosition);
-        Item::equipLoc getInventoryType() const;
-        std::pair<size_t,size_t> *getFloorPosition() const;
-        uint8_t getBeltPosition() const;
-        std::pair<uint8_t, uint8_t> *getInvPosition() const;
-
-        void setInventoryType(Item::equipLoc type);
-        void setFloorPosition(std::pair<size_t,size_t> * pos);
-        void setBeltPosition(uint8_t x);
-        void setInvPosition(std::pair<uint8_t, uint8_t> * pos);
+        ItemPosition(){};
+        ItemPosition(std::pair<size_t, size_t> floorPosition);
+        void setFloorPosition(std::pair<size_t,size_t> pos);
+        std::pair<size_t, size_t> getFloorPosition() const;
         bool operator < (const ItemPosition rhs) const;
         bool operator==(const ItemPosition rhs) const;
-    private:
-        Item::equipLoc mInventoryType;
-        std::pair<size_t,size_t> * mFloorPosition;
-        std::pair<uint8_t, uint8_t> * mInvPosition;
-        uint8_t mBeltPosition;
+    private:        
+        std::pair<size_t,size_t> mFloorPosition;
     };
+
+
+
 
     class ItemManager
     {
     public:
         void loadItems(DiabloExe::DiabloExe * exe);
         static bool mIsLoaded;
-        void addItem(Item &item, Item::equipLoc invType, std::pair<size_t,size_t> *floorPosition, std::pair<uint8_t, uint8_t> *invPosition, uint8_t beltPosition, uint32_t count=0);
+        void addItem(Item &item, std::pair<size_t, size_t> floorPosition, uint32_t count);
         Item getBaseItem(uint8_t id) const;
-        void putItem(
-                Item item,
-                Item::equipLoc to,
-                Item::equipLoc from,
-                std::pair<uint8_t, uint8_t> * invPosition,
-                uint8_t beltX,
-                std::pair<size_t,size_t> * floorPosition);
+        void putItemOnFloor(Item& item, std::pair<size_t, size_t> floor_pos);
 
         void dumpBaseItems() const;
         void dumpItemPositions();

--- a/resources/gui/bottommenu.rml
+++ b/resources/gui/bottommenu.rml
@@ -55,6 +55,7 @@
         </style>
 
         <link type="text/rcss" href="bottommenu_buttons.rcss"/>
+        <link type="text/rcss" href="item_graphics.rcss"/>
 
         <script>
 import docmanage

--- a/resources/gui/inventory.rml
+++ b/resources/gui/inventory.rml
@@ -23,7 +23,6 @@
             }
             div.inventory
             {
-                /*background-color: red;*/
                 position: fixed;
                 left: 16px;
                 top: 222px;
@@ -38,18 +37,15 @@
             div.item
             {
                 display: inline-block;
-                /*background-color:red;*/
                 height: 28px;
                 width: 28px;
                 z-index: 5;
                 position: absolute;
                 background-decorator: image;
-                /*background-image: /data/inv/objcurs.cel&frame=144;*/
             }
 
             div.hand-equip-socket
             {
-                /*background-color: red;*/
                 position: fixed;
                 top: 75px;
                 height:84px;
@@ -68,7 +64,6 @@
 
             div.ring-equip-socket
             {
-                /*background-color: red;*/
                 position: fixed;
                 top: 178px;
                 height:28px;
@@ -78,7 +73,6 @@
             }
             div.head-equip-socket
             {
-                /*background-color: red;*/
                 position: fixed;
                 top: 3px;
                 left: 133px;
@@ -89,7 +83,6 @@
             }
             div.body-equip-socket
             {
-                /*background-color: red;*/
                 position: fixed;
                 top: 75px;
                 left: 133px;
@@ -100,7 +93,6 @@
             }
             div.amulet-equip-socket
             {
-                /*background-color: red;*/
                 position: fixed;
                 top: 32px;
                 left: 200px;
@@ -124,8 +116,6 @@
             {
                 position: relative;
                 display: inline-block;
-                /*background-decorator: image;
-                background-image: /data/inv/objcurs.cel&trans=0,255,0&frame=20;*/
                 top: 0px;
                 left: 1px;
                 width:  29px;
@@ -198,6 +188,5 @@ instance = draggable.DraggableWidget(document, 0, -500)
                              <div class="inv-item-socket" onclick="instance.socketMouseDown(event)" id="inv-item-socket39"></div>
                              </div>
            </span>
-
     </body>
 </rml>

--- a/resources/gui/inventory.rml
+++ b/resources/gui/inventory.rml
@@ -1,5 +1,6 @@
 <rml>
     <head>
+        <link type="text/rcss" href="item_graphics.rcss"/>
         <style>
             body
             {
@@ -102,7 +103,7 @@
                 /*background-color: red;*/
                 position: fixed;
                 top: 32px;
-                left: 205px;
+                left: 200px;
                 height:28px;
                 width: 28px;
                 display: inline-block;

--- a/resources/gui/item_graphics.rcss
+++ b/resources/gui/item_graphics.rcss
@@ -1,0 +1,1352 @@
+div.itemGraphic11
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=11;
+}
+div.itemGraphic12
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=12;
+}
+div.itemGraphic13
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=13;
+}
+div.itemGraphic14
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=14;
+}
+div.itemGraphic15
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=15;
+}
+div.itemGraphic16
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=16;
+}
+div.itemGraphic17
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=17;
+}
+div.itemGraphic18
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=18;
+}
+div.itemGraphic19
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=19;
+}
+div.itemGraphic20
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=20;
+}
+div.itemGraphic21
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=21;
+}
+div.itemGraphic22
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=22;
+}
+div.itemGraphic23
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=23;
+}
+div.itemGraphic24
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=24;
+}
+div.itemGraphic25
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=25;
+}
+div.itemGraphic26
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=26;
+}
+div.itemGraphic27
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=27;
+}
+div.itemGraphic28
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=28;
+}
+div.itemGraphic29
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=29;
+}
+div.itemGraphic30
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=30;
+}
+div.itemGraphic31
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=31;
+}
+div.itemGraphic32
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=32;
+}
+div.itemGraphic33
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=33;
+}
+div.itemGraphic34
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=34;
+}
+div.itemGraphic35
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=35;
+}
+div.itemGraphic36
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=36;
+}
+div.itemGraphic37
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=37;
+}
+div.itemGraphic38
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=38;
+}
+div.itemGraphic39
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=39;
+}
+div.itemGraphic40
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=40;
+}
+div.itemGraphic41
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=41;
+}
+div.itemGraphic42
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=42;
+}
+div.itemGraphic43
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=43;
+}
+div.itemGraphic44
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=44;
+}
+div.itemGraphic45
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=45;
+}
+div.itemGraphic46
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=46;
+}
+div.itemGraphic47
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=47;
+}
+div.itemGraphic48
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=48;
+}
+div.itemGraphic49
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=49;
+}
+div.itemGraphic50
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=50;
+}
+div.itemGraphic51
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=51;
+}
+div.itemGraphic52
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=52;
+}
+div.itemGraphic53
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=53;
+}
+div.itemGraphic54
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=54;
+}
+div.itemGraphic55
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=55;
+}
+div.itemGraphic56
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=56;
+}
+div.itemGraphic57
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=57;
+}
+div.itemGraphic58
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=58;
+}
+div.itemGraphic59
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=59;
+}
+div.itemGraphic60
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=60;
+}
+div.itemGraphic61
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=61;
+}
+div.itemGraphic62
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=62;
+}
+div.itemGraphic63
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=63;
+}
+div.itemGraphic64
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=64;
+}
+div.itemGraphic65
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=65;
+}
+div.itemGraphic66
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=66;
+}
+div.itemGraphic67
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=67;
+}
+div.itemGraphic68
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=68;
+}
+div.itemGraphic69
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=69;
+}
+div.itemGraphic70
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=70;
+}
+div.itemGraphic71
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=71;
+}
+div.itemGraphic72
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=72;
+}
+div.itemGraphic73
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=73;
+}
+div.itemGraphic74
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=74;
+}
+div.itemGraphic75
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=75;
+}
+div.itemGraphic76
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=76;
+}
+div.itemGraphic77
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=77;
+}
+div.itemGraphic78
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=78;
+}
+div.itemGraphic79
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=79;
+}
+div.itemGraphic80
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=80;
+}
+div.itemGraphic81
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=81;
+}
+div.itemGraphic82
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=82;
+}
+div.itemGraphic83
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=83;
+}
+div.itemGraphic84
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=84;
+}
+div.itemGraphic85
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=85;
+}
+div.itemGraphic86
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=86;
+}
+div.itemGraphic87
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=87;
+}
+div.itemGraphic88
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=88;
+}
+div.itemGraphic89
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=89;
+}
+div.itemGraphic90
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=90;
+}
+div.itemGraphic91
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=91;
+}
+div.itemGraphic92
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=92;
+}
+div.itemGraphic93
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=93;
+}
+div.itemGraphic94
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=94;
+}
+div.itemGraphic95
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=95;
+}
+div.itemGraphic96
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=96;
+}
+div.itemGraphic97
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=97;
+}
+div.itemGraphic98
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=98;
+}
+div.itemGraphic99
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=99;
+}
+div.itemGraphic100
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=100;
+}
+div.itemGraphic101
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=101;
+}
+div.itemGraphic102
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=102;
+}
+div.itemGraphic103
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=103;
+}
+div.itemGraphic104
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=104;
+}
+div.itemGraphic105
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=105;
+}
+div.itemGraphic106
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=106;
+}
+div.itemGraphic107
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=107;
+}
+div.itemGraphic108
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=108;
+}
+div.itemGraphic109
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=109;
+}
+div.itemGraphic110
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=110;
+}
+div.itemGraphic111
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=111;
+}
+div.itemGraphic112
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=112;
+}
+div.itemGraphic113
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=113;
+}
+div.itemGraphic114
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=114;
+}
+div.itemGraphic115
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=115;
+}
+div.itemGraphic116
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=116;
+}
+div.itemGraphic117
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=117;
+}
+div.itemGraphic118
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=118;
+}
+div.itemGraphic119
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=119;
+}
+div.itemGraphic120
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=120;
+}
+div.itemGraphic121
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=121;
+}
+div.itemGraphic122
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=122;
+}
+div.itemGraphic123
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=123;
+}
+div.itemGraphic124
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=124;
+}
+div.itemGraphic125
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=125;
+}
+div.itemGraphic126
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=126;
+}
+div.itemGraphic127
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=127;
+}
+div.itemGraphic128
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=128;
+}
+div.itemGraphic129
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=129;
+}
+div.itemGraphic130
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=130;
+}
+div.itemGraphic131
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=131;
+}
+div.itemGraphic132
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=132;
+}
+div.itemGraphic133
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=133;
+}
+div.itemGraphic134
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=134;
+}
+div.itemGraphic135
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=135;
+}
+div.itemGraphic136
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=136;
+}
+div.itemGraphic137
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=137;
+}
+div.itemGraphic138
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=138;
+}
+div.itemGraphic139
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=139;
+}
+div.itemGraphic140
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=140;
+}
+div.itemGraphic141
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=141;
+}
+div.itemGraphic142
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=142;
+}
+div.itemGraphic143
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=143;
+}
+div.itemGraphic144
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=144;
+}
+div.itemGraphic145
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=145;
+}
+div.itemGraphic146
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=146;
+}
+div.itemGraphic147
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=147;
+}
+div.itemGraphic148
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=148;
+}
+div.itemGraphic149
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=149;
+}
+div.itemGraphic150
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=150;
+}
+div.itemGraphic151
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=151;
+}
+div.itemGraphic152
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=152;
+}
+div.itemGraphic153
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=153;
+}
+div.itemGraphic154
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=154;
+}
+div.itemGraphic155
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=155;
+}
+div.itemGraphic156
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=156;
+}
+div.itemGraphic157
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=157;
+}
+div.itemGraphic158
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=158;
+}
+div.itemGraphic159
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=159;
+}
+div.itemGraphic160
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=160;
+}
+div.itemGraphic161
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=161;
+}
+div.itemGraphic162
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=162;
+}
+div.itemGraphic163
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=163;
+}
+div.itemGraphic164
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=164;
+}
+div.itemGraphic165
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=165;
+}
+div.itemGraphic166
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=166;
+}
+div.itemGraphic167
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=167;
+}
+div.itemGraphic168
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=168;
+}
+div.itemGraphic169
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=169;
+}
+div.itemGraphic170
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=170;
+}
+div.itemGraphic171
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=171;
+}
+div.itemGraphic172
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=172;
+}
+div.itemGraphic173
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=173;
+}
+div.itemGraphic174
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=174;
+}
+div.itemGraphic175
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=175;
+}
+div.itemGraphic176
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=176;
+}
+div.itemGraphic177
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=177;
+}
+div.itemGraphic178
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=178;
+}
+div.itemGraphic179
+{
+    display: inline-block;
+    z-index: 5;
+    position: absolute;
+    background-decorator: image;
+    background-image: /data/inv/objcurs.cel&frame=179;
+}

--- a/resources/python/draggable.py
+++ b/resources/python/draggable.py
@@ -29,13 +29,14 @@ class DraggableWidget(object):
         leftHandItem = inventory["leftHand"]
         leftHandContainer = self.document.GetElementById("leftHand")
         leftHand = self.document.CreateElement("div")
-        leftHand.SetAttribute("class", "item")
+
 
 
         if leftHandItem["empty"] is False:
             leftHand.SetAttribute("empty", "false")
             leftHand.style.width = "56px"
             leftHand.style.height = "84px"
+            leftHand.SetAttribute("class", "itemGraphic" + str(leftHandItem["graphic"]))
 
         else:
             leftHand.style.width = "0"
@@ -46,12 +47,12 @@ class DraggableWidget(object):
         rightHandItem = inventory["rightHand"]
         rightHandContainer = self.document.GetElementById("rightHand")
         rightHand = self.document.CreateElement("div")
-        rightHand.SetAttribute("class", "item")
 
         if rightHandItem["empty"] is False:
             rightHand.SetAttribute("empty", "false")
             rightHand.style.width = "56px"
             rightHand.style.height = "84px"
+            rightHand.SetAttribute("class", "itemGraphic" + str(rightHandItem["graphic"]))
 
         else:
             rightHand.style.width = "0"
@@ -62,12 +63,14 @@ class DraggableWidget(object):
         bodyItem = inventory["body"]
         bodyContainer = self.document.GetElementById("body")
         body = self.document.CreateElement("div")
-        body.SetAttribute("class", "item")
+
 
         if bodyItem["empty"] is False:
             body.SetAttribute("empty", "false")
             body.style.width = "57px"
             body.style.height = "87px"
+            body.SetAttribute("class", "itemGraphic" + str(bodyItem["graphic"]))
+
 
         else:
             body.style.width = "0"
@@ -78,12 +81,12 @@ class DraggableWidget(object):
         headItem = inventory["head"]
         headContainer = self.document.GetElementById("head")
         head = self.document.CreateElement("div")
-        head.SetAttribute("class", "item")
 
         if headItem["empty"] is False:
             head.SetAttribute("empty", "false")
             head.style.width = "56px"
             head.style.height = "56px"
+            head.SetAttribute("class", "itemGraphic" + str(headItem["graphic"]))
 
         else:
             head.style.width = "0"
@@ -94,12 +97,12 @@ class DraggableWidget(object):
         amuletItem = inventory["amulet"]
         amuletContainer = self.document.GetElementById("amulet")
         amulet = self.document.CreateElement("div")
-        amulet.SetAttribute("class", "item")
 
         if amuletItem["empty"] is False:
             amulet.SetAttribute("empty", "false")
             amulet.style.width = "28px"
             amulet.style.height = "28px"
+            amulet.SetAttribute("class", "itemGraphic" + str(amuletItem["graphic"]))
 
         else:
             amulet.style.width = "0"
@@ -110,12 +113,12 @@ class DraggableWidget(object):
         leftRingItem = inventory["leftRing"]
         leftRingContainer = self.document.GetElementById("leftRing")
         leftRing = self.document.CreateElement("div")
-        leftRing.SetAttribute("class", "item")
 
         if leftRingItem["empty"] is False:
             leftRing.SetAttribute("empty", "false")
             leftRing.style.width = "28px"
             leftRing.style.height = "28px"
+            leftRing.SetAttribute("class", "itemGraphic" + str(leftRingItem["graphic"]))
 
         else:
             leftRing.style.width = "0"
@@ -126,12 +129,12 @@ class DraggableWidget(object):
         rightRingItem = inventory["rightRing"]
         rightRingContainer = self.document.GetElementById("rightRing")
         rightRing = self.document.CreateElement("div")
-        rightRing.SetAttribute("class", "item")
 
         if rightRingItem["empty"] is False:
             rightRing.SetAttribute("empty", "false")
             rightRing.style.width = "28px"
             rightRing.style.height = "28px"
+            rightRing.SetAttribute("class", "itemGraphic" + str(rightRingItem["graphic"]))
 
         else:
             rightRing.style.width = "0"
@@ -149,13 +152,9 @@ class DraggableWidget(object):
             element.SetAttribute("InvX", str(item["invX"]))
             element.SetAttribute("InvY", str(item["invY"]))
             if item["empty"] is False:
-                element.SetAttribute("class", "item")
-                element.style.backgroundImage = "/data/inv/objcurs.cel&frame=" +str(item["graphic"]);
-                #element.style.display = "inline-block"
-                element.SetAttribute("onClick", "instance.onItemClick(event)")
+                element.SetAttribute("class", "itemGraphic"+str(item["graphic"]))
                 element.SetAttribute("SizeX", str(item["sizeX"]))
                 element.SetAttribute("SizeY", str(item["sizeY"]))
-                #element.style.backgroundDecorator = "image;"
                 element.style.width = str(28*item["sizeX"])
                 element.style.height = str(28*item["sizeY"])
                 element.SetAttribute("CornerX", str(item["cornerX"]))
@@ -165,6 +164,7 @@ class DraggableWidget(object):
                 else:
                     element.style.display = "none"
                     element.SetAttribute("real", "false")
+
             parent.AppendChild(element)
 
     def onLoad(self, event):
@@ -191,22 +191,15 @@ class DraggableWidget(object):
             element.SetAttribute("BeltX", str(i))
             element.SetAttribute("empty", "false")
             element.SetAttribute("class", "beltItem")
-            if item["empty"] is False:
-
-                element.style.backgroundImage = "/data/inv/objcurs.cel&frame=" +str(item["graphic"]);
-                element.style.width = "29px"
-                element.style.height = "29px"
-                #element.style.backgroundDecorator= "image";
+            if item["empty"] is False:             
+                element.SetAttribute("class", "itemGraphic" + str(item["graphic"]));
+                element.style.width = "28px"
+                element.style.height = "28px"
             else:
                 element.SetAttribute("empty", "true")
                 element.style.width="0px"
                 element.style.height="0px"
             parent.AppendChild(element)
-
-
-
-
-
 
     def onDrag(self, event):
         mx = event.parameters['mouse_x']
@@ -302,12 +295,12 @@ class DraggableWidget(object):
 
     def socketMouseDown(self, event):
         global cursor
-        if cursor is True and event.current_element.child_nodes[0].GetAttribute("class") == "item":
+        if cursor is True and "itemGraphic" in event.current_element.child_nodes[0].GetAttribute("class"):
             y, x = (int(event.current_element.child_nodes[0].GetAttribute("InvX")), int(event.current_element.child_nodes[0].GetAttribute("InvY")))
             freeablo.placeItem(10, 0, x, y, x, y, 0)
 
 
-        elif cursor is False and event.current_element.child_nodes[0].GetAttribute("class") != "item":
+        elif cursor is False and "itemGraphic" not in event.current_element.child_nodes[0].GetAttribute("class"):
 
             x, y = (int(event.current_element.child_nodes[0].GetAttribute("InvX")), int(event.current_element.child_nodes[0].GetAttribute("InvY")))
 


### PR DESCRIPTION
According to https://forums.librocket.com/viewtopic.php?f=2&t=940 what I described as a bug is just lack of support for setting "background-image" in inline rcss. A workaround was discovered in creating a class for each frame required for the inventory sprites. 