### PR TITLE
Attack bug

### DIFF
--- a/apps/freeablo/faworld/position.cpp
+++ b/apps/freeablo/faworld/position.cpp
@@ -35,8 +35,14 @@ namespace FAWorld
 
     double Position::distanceFrom(Position B)
     {
-        return sqrt(pow(mCurrent.first - B.mCurrent.first, 2) + pow(mCurrent.second - B.mCurrent.second, 2));
+        int dx = mCurrent.first - B.mCurrent.first;
+        int dy = mCurrent.second - B.mCurrent.second;
 
+        double x = pow(dx, 2.0);
+        double y = pow(dy, 2.0);
+        double distance = sqrt(x + y);
+
+        return distance;
     }
 
     std::pair<size_t, size_t> Position::next() const


### PR DESCRIPTION
On my build I couldn't attack from "behind" of monster and left side of monster but I was able to attack from right and bottom side. I found odd behaviour in computing distance to enemy, this patch should fix it. 

Unable to attack:
![unable](https://cloud.githubusercontent.com/assets/5208485/11840167/d4da7818-a3f3-11e5-8efa-87c823013824.png)

Able to attack:
![able](https://cloud.githubusercontent.com/assets/5208485/11840172/e0573dc0-a3f3-11e5-9679-656199e62eda.png)

