### PR TITLE
Add parameter message & short explanation to MPQTool

### DIFF
--- a/apps/mpqtool/main.cpp
+++ b/apps/mpqtool/main.cpp
@@ -7,13 +7,22 @@
 
 #include <faio/faio.h>
 
-int main(int, char** argv)
+int main(int argc, char** argv)
 {
+    if (argc != 3)
+    {
+        std::cout << "The Freeablo MPQ tool accepts two parameters: " << std::endl;
+        std::cout << argv[0] << " <path to file in MPQ> <output file on file system>" << std::endl;
+        std::cout << "The tool extracts the specified file within the Diablo MPQ file and extracts it to ";
+        std::cout << "the output file as requested." << std::endl;
+        return 1;
+    }
+
     FAIO::init();
 
     FAIO::FAFile* file = FAIO::FAfopen(argv[1]);
     FILE* output = fopen(argv[2], "w");
-    
+
     int read = 1;
     uint8_t buffer[1024];
 


### PR DESCRIPTION
In reference to #197. It seems a little improper to not have an error message explaining what the program does and what input it takes when the input requirements are not met. Also it looks like my tabbing may be off (looked right in my editor, damn it !)