### PR TITLE
Level 4 generation

### DIFF
--- a/apps/freeablo/falevelgen/levelgen.cpp
+++ b/apps/freeablo/falevelgen/levelgen.cpp
@@ -581,7 +581,7 @@ namespace FALevelGen
     // Helper function for adding doors
     // Iterates over all blocks on a wall, and adds doors where necessary, looking at what is in the direction
     // indicated by add (1 or -1) to determine if a door is needed
-    void doorAddHelper(Level::Dun& level, int32_t otherCoord, int32_t add, size_t start, size_t end, bool xAxis)
+    void doorAddHelper(Level::Dun& level, int32_t otherCoord, int32_t add, size_t start, size_t end, bool xAxis, size_t levelNum)
     {
         std::vector<std::pair<size_t, size_t> > region;
         bool connected = false;
@@ -633,24 +633,24 @@ namespace FALevelGen
                 }
             }
         }
-
+        
         if(!hole && region.size() > 0)
-            level[region[region.size()/2].first][region[region.size()/2].second] = door;
+            level[region[region.size()/2].first][region[region.size()/2].second] = (levelNum == 4) ? floor : door;
     }
     
-    void addDoors(Level::Dun& level, const std::vector<Room>& rooms)
+    void addDoors(Level::Dun& level, const std::vector<Room>& rooms, size_t levelNum)
     {
         for(size_t i = 0; i < rooms.size(); i++)
         {
             // Top x wall
-            doorAddHelper(level, rooms[i].yPos,                   -1, rooms[i].xPos+1, rooms[i].xPos + rooms[i].width -1,  true); 
+            doorAddHelper(level, rooms[i].yPos,                   -1, rooms[i].xPos+1, rooms[i].xPos + rooms[i].width -1,  true, levelNum); 
             // Bottom x wall
-            doorAddHelper(level, rooms[i].yPos+rooms[i].height-1, +1, rooms[i].xPos+1, rooms[i].xPos + rooms[i].width -1,  true); 
+            doorAddHelper(level, rooms[i].yPos+rooms[i].height-1, +1, rooms[i].xPos+1, rooms[i].xPos + rooms[i].width -1,  true, levelNum); 
             
             // Left y wall
-            doorAddHelper(level, rooms[i].xPos,                   -1, rooms[i].yPos+1, rooms[i].yPos + rooms[i].height -1, false); 
+            doorAddHelper(level, rooms[i].xPos,                   -1, rooms[i].yPos+1, rooms[i].yPos + rooms[i].height -1, false, levelNum); 
             // Right y wall
-            doorAddHelper(level, rooms[i].xPos+rooms[i].width-1,  +1, rooms[i].yPos+1, rooms[i].yPos + rooms[i].height -1, false); 
+            doorAddHelper(level, rooms[i].xPos+rooms[i].width-1,  +1, rooms[i].yPos+1, rooms[i].yPos + rooms[i].height -1, false, levelNum); 
         }
     }
 
@@ -815,7 +815,7 @@ namespace FALevelGen
         addWalls(level);
 
         cleanup(level, rooms); 
-        addDoors(level, rooms);
+        addDoors(level, rooms, levelNum);
         
         // Make sure we always place stairs
         if(!(placeUpStairs(level, rooms, levelNum) && placeDownStairs(level, rooms, levelNum)))

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -57,7 +57,7 @@ namespace FAWorld
         mLevels[0] = tmp;
 
 
-        for(int32_t i = 1; i < 13; i++)
+        for(int32_t i = 1; i < 17; i++)
         {
             mLevels[i] = FALevelGen::generate(100, 100, i, mDiabloExe, i-1, i+1);
         }

--- a/apps/freeablo/main.cpp
+++ b/apps/freeablo/main.cpp
@@ -33,8 +33,8 @@ bool parseOptions(int argc, char** argv, bpo::variables_map& variables)
 
         const int32_t dLvl = variables["level"].as<int32_t>();
 
-        if(dLvl > 12)
-            throw bpo::error("level > 12 not implemented");
+        if(dLvl > 16)
+            throw bpo::error("There is no level after 16");
     }
     catch(bpo::error& e)
     {

--- a/components/cel/celfile.cpp
+++ b/components/cel/celfile.cpp
@@ -193,6 +193,8 @@ namespace Cel
             palFilename = Misc::StringUtils::replaceEnd("l2.cel", "l2.pal", filename);
         else if(Misc::StringUtils::startsWith(filename, "levels") && Misc::StringUtils::endsWith(filename, "l3.cel"))
             palFilename = Misc::StringUtils::replaceEnd("l3.cel", "l3.pal", filename);
+        else if(Misc::StringUtils::startsWith(filename, "levels") && Misc::StringUtils::endsWith(filename, "l4.cel"))
+            palFilename = Misc::StringUtils::replaceEnd("l4.cel", "l4_1.pal", filename);
         else if (Misc::StringUtils::startsWith(Misc::StringUtils::lowerCase(filename), "gendata"))
             palFilename = Misc::StringUtils::replaceEnd(".cel", ".pal", filename);
         else

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -422,11 +422,12 @@ namespace DiabloExe
     std::vector<const Monster*> DiabloExe::getMonstersInLevel(size_t levelNum) const
     {
         std::vector<const Monster*> retval;
-
+        
         for(std::map<std::string, Monster>::const_iterator it = mMonsters.begin(); it != mMonsters.end(); ++it)
         {
-            if(levelNum >= it->second.minDunLevel && levelNum <= it->second.maxDunLevel &&
-               it->second.monsterName != "Wyrm" && it->second.monsterName != "Cave Slug") // Exception, these monster's CEL files don't exist
+            if (levelNum >= it->second.minDunLevel && levelNum <= it->second.maxDunLevel &&
+                    it->second.monsterName != "Wyrm" && it->second.monsterName != "Cave Slug" &&
+                    it->second.monsterName != "Devil Wyrm" && it->second.monsterName != "Devourer") // Exception, these monster's CEL files don't exist
             {
                 retval.push_back(&(it->second));
             }

--- a/resources/tilesets/l4.ini
+++ b/resources/tilesets/l4.ini
@@ -1,0 +1,91 @@
+# Data used to aid level generation
+# Basic section defines the base tiles used to 
+# represent chunks of dungeons
+[Basic]
+xWall = 2
+outsideXWall = 19
+yWall = 1
+outsideYWall = 18
+bottomCorner = 12
+outsideBottomCorner = 24
+rightCorner = 16
+outsideRightCorner = 28
+leftCorner = 15
+outsideLeftCorner = 27
+topCorner = 9
+outsideTopCorner = 21
+floor = 6
+blank = 30
+xWallEnd = 57
+yWallEnd = 53
+xDoor = 6
+yDoor = 6
+
+
+insideXWall = 2
+insideXWallEnd = 57
+insideXWallEndBack = 8
+insideYWall = 1
+insideYWallEnd = 53
+insideYWallEndBack = 7
+insideLeftCorner = 15
+insideRightCorner = 16
+insideBottomCorner = 12
+insideTopCorner = 9
+
+joinY = 10
+joinYRightCorner = 11
+joinRightCorner = 17
+joinOutXRightCorner = 13
+joinOutX  = 26
+joinOutXTopCorner = 22
+joinTopCorner = 29
+joinOutYTopCorner = 23
+joinOutY = 25
+joinOutYLeftCorner = 14
+joinLeftCorner = 17
+joinXLeftCorner = 10
+joinX = 11
+joinXBottomCorner = 13
+joinBottomCorner = 17
+joinYBottomCorner = 14
+
+
+# upStairs values define a 3x3 block of tiles representing stairs up
+upStairs1 = 6
+upStairs2 = 35
+upStairs3 = 6
+
+upStairs4 = 34
+upStairs5 = 33
+upStairs6 = 32
+
+upStairs7 = 6
+upStairs8 = 31
+upStairs9 = 6
+
+# downStairs values define a 3x3 block for stairs down
+downStairs1 = 6
+downStairs2 = 45
+downStairs3 = 41
+
+downStairs4 = 44
+downStairs5 = 43
+downStairs6 = 40
+
+downStairs7 = 46
+downStairs8 = 42
+downStairs9 = 39
+
+# Map of closed door til entries to open door til entries
+[DoorMap]
+# No doors on l4
+
+#
+#
+## All sections other than Basic and DoorMap list aesthetic replacements
+## for their corresponding value
+## normal shows the percentage of tiles that will be the 
+## normal value from the Basic section, all others are of the format
+## "index = weight", where weight adjusts it's frequency relative to the others
+## No section for a block just means it will always be the "basic" version

--- a/resources/tilesets/l4.ini
+++ b/resources/tilesets/l4.ini
@@ -24,10 +24,10 @@ yDoor = 6
 
 insideXWall = 2
 insideXWallEnd = 57
-insideXWallEndBack = 8
+insideXWallEndBack = 56
 insideYWall = 1
 insideYWallEnd = 53
-insideYWallEndBack = 7
+insideYWallEndBack = 52
 insideLeftCorner = 15
 insideRightCorner = 16
 insideBottomCorner = 12


### PR DESCRIPTION
Hello,
This patch should give the level 4 generation basics (#104).

Few notes:
* There are no doors in L4, so I replaced the door by floor before the tiling of the level and let the tiling function do its job to add *WallEnd. It gives quite good results.

* Tell me if I'm wrong, but with the L4, there is a glitch with the current generation algorithm, Corners are slightly different for L4. See the difference between L2 & L4 in the screenshots above.

![joinl2](https://cloud.githubusercontent.com/assets/1209014/14426265/1ef52a3c-ffee-11e5-8906-b381c065cbdd.png)
![joinl4](https://cloud.githubusercontent.com/assets/1209014/14426266/1ef5c172-ffee-11e5-82e6-aced4e618242.png)

For L4 there is two different corners, one for simple corner and one for a tri-join corner, _insideRightCorner_ should have the tile ID 16 but also the tile ID 13 version to handle this precise case.
So, the algo has to be modified to fix that. It will dive in it.


Tell me if it's okay for you.

Thanks!