### PR TITLE
Add inventory hotkey

### DIFF
--- a/apps/freeablo/engine/engineinputmanager.cpp
+++ b/apps/freeablo/engine/engineinputmanager.cpp
@@ -159,6 +159,9 @@ namespace Engine
             case QUIT:
                 actionAsString = "Quit";
                 break;
+            case INVENTORY:
+                actionAsString = "Inventory";
+                break;
             case NOCLIP:
                 actionAsString = "Noclip";
                 break;

--- a/apps/freeablo/engine/enginemain.cpp
+++ b/apps/freeablo/engine/enginemain.cpp
@@ -93,7 +93,7 @@ namespace Engine
 
         int32_t currentLevel = variables["level"].as<int32_t>();
 
-        FAGui::GuiManager guiManager(player->mInventory, *this, characterClass);
+        mGuiManager = std::make_shared<FAGui::GuiManager>(player->mInventory, *this, characterClass);
 
         // -1 represents the main menu
         if(currentLevel != -1 && isServer)
@@ -103,7 +103,7 @@ namespace Engine
             FAWorld::GameLevel& level = *world.getCurrentLevel();
 
             player->mPos = FAWorld::Position(level.upStairsPos().first, level.upStairsPos().second);
-            guiManager.showIngameGui();
+            mGuiManager->showIngameGui();
         }
         else
         {
@@ -111,11 +111,11 @@ namespace Engine
             bool showTitleScreen = settings.get<bool>("Game", "showTitleScreen");
             if(showTitleScreen)
             {
-                guiManager.showTitleScreen();
+                mGuiManager->showTitleScreen();
             }
             else
             {
-                guiManager.showMainMenu();
+                mGuiManager->showMainMenu();
             }
         }
 
@@ -135,7 +135,7 @@ namespace Engine
             }
 
             netManager.update();
-            guiManager.update(mPaused);
+            mGuiManager->update(mPaused);
 
             FAWorld::GameLevel* level = world.getCurrentLevel();
             FARender::RenderState* state = renderer.getFreeState();
@@ -177,6 +177,10 @@ namespace Engine
         if(action == QUIT)
         {
             stop();
+        }
+        else if (action == INVENTORY)
+        {
+            mGuiManager->toggleDialogue("resources/gui/inventory.rml");
         }
         else if(action == NOCLIP)
         {

--- a/apps/freeablo/engine/enginemain.h
+++ b/apps/freeablo/engine/enginemain.h
@@ -19,6 +19,11 @@ namespace DiabloExe
     class DiabloExe;
 }
 
+namespace FAGui
+{
+    class GuiManager;
+}
+
 namespace Engine
 {
     class EngineMain : public KeyboardInputObserverInterface
@@ -36,6 +41,7 @@ namespace Engine
             void runGameLoop(const boost::program_options::variables_map& variables, const std::string& pathEXE);
 
             std::shared_ptr<EngineInputManager> mInputManager;
+            std::shared_ptr<FAGui::GuiManager> mGuiManager;
             bool mDone = false;
             bool mPaused = false;
             bool mNoclip = false;

--- a/apps/freeablo/engine/inputobserverinterface.h
+++ b/apps/freeablo/engine/inputobserverinterface.h
@@ -6,6 +6,7 @@ namespace Engine {
     enum KeyboardInputAction
     {
         QUIT,
+        INVENTORY,
         NOCLIP,
         CHANGE_LEVEL_DOWN,
         CHANGE_LEVEL_UP,

--- a/apps/freeablo/fagui/guimanager.cpp
+++ b/apps/freeablo/fagui/guimanager.cpp
@@ -1,4 +1,4 @@
-﻿#include "guimanager.h"
+#include "guimanager.h"
 
 #include <string>
 
@@ -15,7 +15,7 @@
 
 
 namespace FAGui
-{   
+{
     std::map<std::string, Rocket::Core::ElementDocument*> menus;
 
     std::string GuiManager::invClass;
@@ -61,6 +61,21 @@ namespace FAGui
         if(mDocument != nullptr)
             mDocument->Close();
         mDocument = nullptr;
+    }
+
+    void GuiManager::toggleDialogue(const std::string& document)
+    {
+        if (!isDialogueOpened())
+        {
+            openDialogue(document);
+        }
+        else
+        {
+            if (mDocument->IsVisible())
+                mDocument->Hide();
+            else
+                mDocument->Show();
+        }
     }
 
     bool GuiManager::isDialogueOpened() const

--- a/apps/freeablo/fagui/guimanager.h
+++ b/apps/freeablo/fagui/guimanager.h
@@ -38,6 +38,7 @@ namespace FAGui
 
         void openDialogue(const std::string& document);
         void closeDialogue();
+        void toggleDialogue(const std::string& document);
         bool isDialogueOpened() const;
         void openDialogueScrollbox(const std::string& document);
         void closeDialogueScrollbox();

--- a/resources/hotkeys.ini
+++ b/resources/hotkeys.ini
@@ -3,6 +3,11 @@ key=113
 shift=0
 ctrl=0
 alt=0
+[Inventory]
+key=105
+shift=0
+ctrl=0
+alt=0
 [Noclip]
 key=110
 shift=0


### PR DESCRIPTION
Hit `i` to open the inventory dialogue.  Hit again to hide it.

toggleDialogue:
In case we want to control the dialogues with a hotkey, it is convenient
to open when closed and close when opened.  This simplifies the client
code checks for the state of the dialogue.
