### PR TITLE
Rendering Refactoring

### DIFF
--- a/apps/celview/mainwindow.cpp
+++ b/apps/celview/mainwindow.cpp
@@ -25,11 +25,11 @@ MainWindow::MainWindow(QWidget *parent) :
 
     ui->currentFrame->setValidator(new QIntValidator(0, 9999999, this));
     ui->currentFrame->setText("0");
-    
+
     qDebug() << mSettingsFile;
 
     loadSettings();
-    initRender();    
+    initRender();
 }
 
 MainWindow::~MainWindow()
@@ -148,14 +148,14 @@ void MainWindow::on_leftButton_clicked()
     {
         mCurrentFrame = mCurrentCel->size() - 1;
     }
-        
+
     ui->currentFrame->setText(QString::number(mCurrentFrame));
 }
 
 void MainWindow::on_rightButton_clicked()
 {
     if (!mCurrentCel)
-        return; 
+        return;
 
     mCurrentFrame++;
     if (mCurrentFrame >= (int)mCurrentCel->size())
@@ -181,7 +181,7 @@ void MainWindow::on_actionExport_CEL_CL2_to_PNG_triggered()
     QString tmpFilename = QFileDialog::getSaveFileName(this, tr("Save CEL/CL2 as PNG"), ".", tr("PNG Files (*.png)"));
     if (!tmpFilename.isEmpty())
     {
-        Render::SpriteGroup::toPng(mCurrentCelFilename.toStdString(), tmpFilename.toStdString());   
+        Render::SpriteGroup::toPng(mCurrentCelFilename.toStdString(), tmpFilename.toStdString());
         QMessageBox::information(0, "Success", "Export complete!");
     }
 }
@@ -203,12 +203,12 @@ void MainWindow::on_actionExport_all_CEL_CL2_to_PNG_triggered()
             QString pathInMPQ = ui->listView->item(i)->text();
             QString modifiedPathInMPQ = pathInMPQ;
             modifiedPathInMPQ = modifiedPathInMPQ.replace('\\', '_').replace('/','_').replace(".cel", ".png").replace(".cl2",".png");
-            
+
             std::string stdModifiedPathInMPQ = modifiedPathInMPQ.toStdString();
             std::string path = pathInMPQ.toStdString();
             std::string target = dir.toStdString() + "/" + stdModifiedPathInMPQ;
 
-            Render::SpriteGroup::toPng(path, target);  
+            Render::SpriteGroup::toPng(path, target);
         }
 
         QMessageBox::information(0, "Success", "Export complete!");
@@ -245,7 +245,7 @@ void MainWindow::updateRender()
     Render::clear(mBackgroundColor.red(), mBackgroundColor.green(), mBackgroundColor.blue());
 
     if(mCurrentCel->size() > 0)
-        Render::drawAt((*mCurrentCel)[mCurrentFrame], 0, 0);
+      Render::drawSprite((SDL_Texture*)(*mCurrentCel)[mCurrentFrame], 0, 0);
     Render::draw();
 }
 
@@ -321,7 +321,7 @@ void MainWindow::listFilesDetails(QString extension, QStringList & list)
 
     SFILE_FIND_DATA findFileData;
     HANDLE findHandle = SFileFindFirstFile(mDiabdat, extension.toStdString().c_str(), &findFileData, NULL);
-    
+
     list.append(QString(findFileData.cFileName));
 
     while (SFileFindNextFile(findHandle, &findFileData))
@@ -332,15 +332,15 @@ void MainWindow::listFilesDetails(QString extension, QStringList & list)
     SFileFindClose(findHandle);
 }
 
-bool MainWindow::fileExists(QString path) 
+bool MainWindow::fileExists(QString path)
 {
     QFileInfo checkFile(path);
 
-    if (checkFile.exists() && checkFile.isFile()) 
+    if (checkFile.exists() && checkFile.isFile())
     {
         return true;
     }
-    else 
+    else
     {
         return false;
     }

--- a/apps/freeablo/farender/renderer.cpp
+++ b/apps/freeablo/farender/renderer.cpp
@@ -182,9 +182,9 @@ namespace FARender
         return mSpriteManager.getPathForIndex(index);
     }
 
-    Render::Tile Renderer::getClickedTile(size_t x, size_t y, const FAWorld::GameLevel& level, const FAWorld::Position& screenPos)
+    Render::Tile Renderer::getClickedTile(size_t x, size_t y, const FAWorld::Position& screenPos)
     {
-        return Render::getClickedTile(level.mLevel, x, y, screenPos.current().first, screenPos.current().second, screenPos.next().first, screenPos.next().second, screenPos.mDist);
+        return Render::getClickedTile(x, y, screenPos.current().first, screenPos.current().second, screenPos.next().first, screenPos.next().second, screenPos.mDist);
     }
 
     Rocket::Core::Context* Renderer::getRocketContext()

--- a/apps/freeablo/farender/renderer.cpp
+++ b/apps/freeablo/farender/renderer.cpp
@@ -26,7 +26,7 @@ namespace FARender
     {
         return mRenderer;
     }
-                                  
+
 
     Renderer::Renderer(int32_t windowWidth, int32_t windowHeight, bool fullscreen)
         :mDone(false)
@@ -43,7 +43,7 @@ namespace FARender
             settings.fullscreen = fullscreen;
 
             Render::init(settings);
-            
+
             mRocketContext = Render::initGui(std::bind(&Renderer::loadGuiTextureFunc, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
                                              std::bind(&Renderer::generateGuiTextureFunc, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
                                              std::bind(&Renderer::releaseGuiTextureFunc, this, std::placeholders::_1));
@@ -161,7 +161,7 @@ namespace FARender
     {
         Engine::ThreadManager::get()->sendRenderState(current);
     }
-    
+
     FASpriteGroup* Renderer::loadImage(const std::string& path)
     {
         return mSpriteManager.get(path);
@@ -182,7 +182,7 @@ namespace FARender
         return mSpriteManager.getPathForIndex(index);
     }
 
-    std::pair<size_t, size_t> Renderer::getClickedTile(size_t x, size_t y, const FAWorld::GameLevel& level, const FAWorld::Position& screenPos)
+    Render::Tile Renderer::getClickedTile(size_t x, size_t y, const FAWorld::GameLevel& level, const FAWorld::Position& screenPos)
     {
         return Render::getClickedTile(level.mLevel, x, y, screenPos.current().first, screenPos.current().second, screenPos.next().first, screenPos.next().second, screenPos.mDist);
     }
@@ -213,7 +213,7 @@ namespace FARender
 
         if(state)
         {
-            
+
             if(state->level)
             {
                 if(mLevelObjects.width() != state->level->width() || mLevelObjects.height() != state->level->height())
@@ -249,7 +249,7 @@ namespace FARender
             Render::drawGui(state->guiDrawBuffer, &mSpriteManager);
             Renderer::setCursor(state);
         }
-        
+
         Render::draw();
 
         return true;

--- a/apps/freeablo/farender/renderer.h
+++ b/apps/freeablo/farender/renderer.h
@@ -81,7 +81,7 @@ namespace FARender
             void fillServerSprite(uint32_t index, const std::string& path);
             std::string getPathForIndex(uint32_t index);
 
-            Render::Tile getClickedTile(size_t x, size_t y, const FAWorld::GameLevel& level, const FAWorld::Position& screenPos);
+            Render::Tile getClickedTile(size_t x, size_t y, const FAWorld::Position& screenPos);
 
             Rocket::Core::Context* getRocketContext();
 

--- a/apps/freeablo/farender/renderer.h
+++ b/apps/freeablo/farender/renderer.h
@@ -23,7 +23,7 @@ namespace FAWorld
 }
 
 namespace FARender
-{       
+{
 
     class Renderer;
     class Tileset
@@ -64,7 +64,7 @@ namespace FARender
     {
         public:
             static Renderer* get();
-            
+
             Renderer(int32_t windowWidth, int32_t windowHeight, bool fullscreen);
             ~Renderer();
 
@@ -81,7 +81,7 @@ namespace FARender
             void fillServerSprite(uint32_t index, const std::string& path);
             std::string getPathForIndex(uint32_t index);
 
-            std::pair<size_t, size_t> getClickedTile(size_t x, size_t y, const FAWorld::GameLevel& level, const FAWorld::Position& screenPos);
+            Render::Tile getClickedTile(size_t x, size_t y, const FAWorld::GameLevel& level, const FAWorld::Position& screenPos);
 
             Rocket::Core::Context* getRocketContext();
 
@@ -90,7 +90,7 @@ namespace FARender
             bool renderFrame(RenderState* state); ///< To be called only by Engine::ThreadManager
             void cleanup(); ///< To be called only by Engine::ThreadManager
 
-            
+
         private:
             bool loadGuiTextureFunc(Rocket::Core::TextureHandle& texture_handle, Rocket::Core::Vector2i& texture_dimensions, const Rocket::Core::String& source);
             bool generateGuiTextureFunc(Rocket::Core::TextureHandle& texture_handle, const Rocket::Core::byte* source, const Rocket::Core::Vector2i& source_dimensions);

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -267,7 +267,8 @@ namespace FAWorld
         auto player = getCurrentPlayer();
         auto level = getCurrentLevel();
         std::pair<int32_t, int32_t>& destination = player->destination();
-        destination = FARender::Renderer::get()->getClickedTile(mousePosition.x, mousePosition.y, *level, player->mPos);
+        auto clickedTile = FARender::Renderer::get()->getClickedTile(mousePosition.x, mousePosition.y, *level, player->mPos);
+        destination = {clickedTile.x, clickedTile.y};
         mDestination = player->mPos.mGoal = destination; //update it.
     }
 

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -265,9 +265,8 @@ namespace FAWorld
     void World::onMouseDown(Engine::Point mousePosition)
     {
         auto player = getCurrentPlayer();
-        auto level = getCurrentLevel();
         std::pair<int32_t, int32_t>& destination = player->destination();
-        auto clickedTile = FARender::Renderer::get()->getClickedTile(mousePosition.x, mousePosition.y, *level, player->mPos);
+        auto clickedTile = FARender::Renderer::get()->getClickedTile(mousePosition.x, mousePosition.y, player->mPos);
         destination = {clickedTile.x, clickedTile.y};
         mDestination = player->mPos.mGoal = destination; //update it.
     }

--- a/components/level/level.h
+++ b/components/level/level.h
@@ -27,11 +27,11 @@ namespace Level
             int16_t operator[] (size_t index) const;
             bool passable() const;
             int32_t index() const;
-        
+
         private:
             MinPillar(const std::vector<int16_t>& data, bool passable, int32_t index);
             const std::vector<int16_t>& mData;
-            
+
             bool mPassable;
             int32_t mIndex;
 
@@ -43,7 +43,7 @@ namespace Level
     class Level
     {
         public:
-            Level(const Dun& dun, const std::string& tilPath, const std::string& minPath, 
+            Level(const Dun& dun, const std::string& tilPath, const std::string& minPath,
                 const std::string& solPath, const std::string& tileSetPath, const std::pair<size_t,size_t>& downStairs,
                 const std::pair<size_t,size_t>& upStairs, std::map<size_t, size_t> doorMap, size_t previous, size_t next);
 

--- a/components/misc/misc.h
+++ b/components/misc/misc.h
@@ -14,6 +14,16 @@ namespace Misc
     {
         return std::make_pair(((float)to.first)-((float)from.first), ((float)to.second)-((float)from.second));
     }
+
+    // Point in pixels
+    struct Point
+    {
+      int32_t x;
+      int32_t y;
+      Point operator+ (const Point &v) const { return {x + v.x, y + v.y}; }
+      Point operator- (const Point &v) const { return {x - v.x, y - v.y}; }
+      Point operator* (double c) const { return {static_cast<int32_t> (x * c), static_cast<int32_t> (y * c)}; }
+    };
 }
 
 #define UNUSED_PARAM(x) (void)(x)

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -36,28 +36,6 @@ namespace Level
 
 namespace Render
 {
-    // Difference between two points
-    struct Vector
-    {
-      int32_t x;
-      int32_t y;
-
-      Vector operator* (const double &scalar) const
-      {
-        return {static_cast<int32_t> (x * scalar), static_cast<int32_t> (y * scalar)};
-      }
-    };
-
-    // Point in pixels
-    struct Point
-    {
-      int32_t x;
-      int32_t y;
-      Point operator+ (const Vector &v) const { return {x + v.x, y + v.y}; }
-      Point operator- (const Vector &v) const { return {x - v.x, y - v.y}; }
-      Vector operator- (const Point &other) const { return {x - other.x, y - other.y}; }
-    };
-
     // Tile mesasured in indexes on tile grid
     struct Tile
     {

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -155,7 +155,7 @@ namespace Render
     SpriteGroup* loadTilesetSprite(const std::string& celPath, const std::string& minPath, bool top);
     void drawLevel(const Level::Level& level, size_t minTopsHandle, size_t minBottomsHandle, SpriteCacheBase* cache, LevelObjects& objs, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist);
 
-    Tile getClickedTile(const Level::Level& level, size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist);
+    Tile getClickedTile(size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist);
 
     void clear(int r = 0, int g = 0, int b = 255);
 }

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -36,6 +36,34 @@ namespace Level
 
 namespace Render
 {
+    // Difference between two points
+    struct Vector
+    {
+      int32_t x;
+      int32_t y;
+
+      Vector operator* (const double &scalar) const
+      {
+        return {static_cast<int32_t> (x * scalar), static_cast<int32_t> (y * scalar)};
+      }
+    };
+
+    // Point in pixels
+    struct Point
+    {
+      int32_t x;
+      int32_t y;
+      Point operator+ (const Vector &v) const { return {x + v.x, y + v.y}; }
+      Point operator- (const Vector &v) const { return {x - v.x, y - v.y}; }
+      Vector operator- (const Point &other) const { return {x - other.x, y - other.y}; }
+    };
+
+    // Tile mesasured in indexes on tile grid
+    struct Tile
+    {
+      int32_t x;
+      int32_t y;
+    };
     /**
      * @brief Render settings for initialization.
      */
@@ -55,12 +83,12 @@ namespace Render
 
 
 
-    void init(const RenderSettings& settings); 
+    void init(const RenderSettings& settings);
     Rocket::Core::Context* initGui(std::function<bool(Rocket::Core::TextureHandle&, Rocket::Core::Vector2i&, const Rocket::Core::String&)> loadTextureFunc,
                                    std::function<bool(Rocket::Core::TextureHandle&, const Rocket::Core::byte*, const Rocket::Core::Vector2i&)> generateTextureFunc,
                                    std::function<void(Rocket::Core::TextureHandle)> releaseTextureFunc);
 
-    void quit(); 
+    void quit();
 
     void resize(size_t w, size_t h);
     RenderSettings getWindowSize();
@@ -79,7 +107,7 @@ namespace Render
 
     void draw();
 
-    void drawAt(const Sprite& sprite, size_t x, size_t y); 
+    void drawSprite(const Sprite& sprite, size_t x, size_t y);
 
     class SpriteGroup
     {
@@ -87,7 +115,7 @@ namespace Render
             SpriteGroup(const std::string& path);
             SpriteGroup(const std::vector<Sprite> sprites): mSprites(sprites), mAnimLength(sprites.size()) {}
             void destroy();
-            
+
             Sprite& operator[](size_t index)
             {
                 #ifndef NDEBUG
@@ -102,7 +130,7 @@ namespace Render
             }
 
             size_t animLength()
-            {   
+            {
                 return mAnimLength;
             }
 
@@ -122,12 +150,12 @@ namespace Render
         bool needsImmortal;
     };
 
-    void spriteSize(const Sprite& sprite, size_t& w, size_t& h);
+    void spriteSize(const Sprite& sprite, int32_t& w, int32_t& h);
 
     SpriteGroup* loadTilesetSprite(const std::string& celPath, const std::string& minPath, bool top);
     void drawLevel(const Level::Level& level, size_t minTopsHandle, size_t minBottomsHandle, SpriteCacheBase* cache, LevelObjects& objs, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist);
-    
-    std::pair<int32_t, int32_t> getClickedTile(const Level::Level& level, size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist);
+
+    Tile getClickedTile(const Level::Level& level, size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist);
 
     void clear(int r = 0, int g = 0, int b = 255);
 }

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -555,7 +555,7 @@ namespace Render
     constexpr auto tileHeight = 32;
     constexpr auto tileWidth = tileHeight * 2;
 
-    void drawAtTile(const Sprite& sprite, const Point& tileTop, int spriteW, int spriteH)
+    void drawAtTile(const Sprite& sprite, const Misc::Point& tileTop, int spriteW, int spriteH)
     {
         // centering spright at the center of tile by width and at the bottom of tile by height
         drawSprite(sprite, tileTop.x - spriteW / 2, tileTop.y - spriteH + tileHeight);
@@ -823,25 +823,25 @@ namespace Render
     // basic transform of isometric grid to normal, (0, 0) tile coordinate maps to (0, 0) pixel coordinates
     // since eventually we're gonna shift coordinates to viewport center, it's better to keep transform itself
     // as simple as possible
-    static Point tileTopPoint (const Tile &tile) {
+    static Misc::Point tileTopPoint (const Tile &tile) {
       return {(tileWidth / 2) * (tile.x - tile.y), (tile.y + tile.x) * (tileHeight / 2)};
     }
 
     // this function simply does the reverse of the above function, could be found by solving linear equation system
     // it obviously uses the fact that ttileWidth = tileHeight * 2
-    Tile getTileFromScreenCoords(const Point& screenPos, const Vector& toScreen)
+    Tile getTileFromScreenCoords(const Misc::Point& screenPos, const Misc::Point& toScreen)
     {
         auto point = screenPos - toScreen;
         return {(2 * point.y + point.x) / tileWidth, (2 * point.y - point.x) / tileWidth}; // divisin by 64 is pretty fast btw
     }
 
-    static Point pointBetween (const Tile &start, const Tile &finish, const size_t &percent) {
+    static Misc::Point pointBetween (const Tile &start, const Tile &finish, const size_t &percent) {
       auto pointA = tileTopPoint (start);
       auto pointB = tileTopPoint (finish);
       return pointA + (pointB - pointA) * (percent * 0.01);
     }
 
-    void drawMovingSprite(const Sprite& sprite, const Tile& start, const Tile& finish, size_t dist, const Vector& toScreen)
+    void drawMovingSprite(const Sprite& sprite, const Tile& start, const Tile& finish, size_t dist, const Misc::Point& toScreen)
     {
         int32_t w, h;
         spriteSize(sprite, w, h);
@@ -850,11 +850,11 @@ namespace Render
         drawAtTile(sprite, res, w, h);
     }
 
-  constexpr auto bottomMenuSize = 144; // TODO: pass it as a variable
-  Vector worldToScreenVector(const Tile& start, const Tile& finish, size_t dist)
+    constexpr auto bottomMenuSize = 144; // TODO: pass it as a variable
+    Misc::Point worldToScreenVector(const Tile& start, const Tile& finish, size_t dist)
     {
         // centering takes in accord bottom menu size to be consistent with original game centering
-        return Point{WIDTH / 2, (HEIGHT - bottomMenuSize) / 2} - pointBetween(start, finish, dist);
+        return Misc::Point{WIDTH / 2, (HEIGHT - bottomMenuSize) / 2} - pointBetween(start, finish, dist);
     }
 
     Tile getClickedTile(size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist)
@@ -866,9 +866,9 @@ namespace Render
     constexpr auto staticObjectHeight = 256;
 
     template <typename ProcessTileFunc>
-    void drawObjectsByTiles (const Vector &toScreen, ProcessTileFunc processTile)
+    void drawObjectsByTiles (const Misc::Point &toScreen, ProcessTileFunc processTile)
     {
-      Point start {-tileWidth, -tileHeight};
+      Misc::Point start {-tileWidth, -tileHeight};
       auto startingTile = getTileFromScreenCoords(start, toScreen);
 
       auto startingPoint = tileTopPoint(startingTile) + toScreen;
@@ -904,7 +904,7 @@ namespace Render
       auto isInvalidTile = [&](const Tile &tile){ return tile.x < 0 || tile.y < 0 || tile.x >= static_cast<int32_t> (level.width()) || tile.y >= static_cast<int32_t> (level.height());};
 
       // drawing on the ground objects
-      drawObjectsByTiles (toScreen, [&](const Tile &tile, const Point &topLeft){
+      drawObjectsByTiles (toScreen, [&](const Tile &tile, const Misc::Point &topLeft){
           // Fill invalid tiles with ground, it looks ok but it's probably better to have something else than zero-eth sprite here
           if (isInvalidTile (tile))
             return drawAtTile ((*minBottoms)[0], topLeft, tileWidth, staticObjectHeight);
@@ -918,7 +918,7 @@ namespace Render
       cache->setImmortal(minTopsHandle, true);
 
       // drawing above the ground and moving object
-      drawObjectsByTiles (toScreen, [&](const Tile &tile, const Point &topLeft){
+      drawObjectsByTiles (toScreen, [&](const Tile &tile, const Misc::Point &topLeft){
         if (isInvalidTile (tile))
           return;
 

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -920,8 +920,9 @@ namespace Render
 
       // drawing on the ground objects
       drawObjectsByTiles (toScreen, [&](const Tile &tile, const Point &topLeft){
+          // Fill invalid tiles with ground, it looks ok but it's probably better to have something else than zero-eth sprite here
           if (isInvalidTile (tile))
-            return;
+            return drawAtTile ((*minBottoms)[0], topLeft, tileWidth, staticObjectHeight);
 
         size_t index = level[tile.x][tile.y].index();
         if(index < minBottoms->size())

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -871,11 +871,7 @@ namespace Render
     template <typename ProcessTileFunc>
     void drawObjectsByTiles (const Vector &toScreen, ProcessTileFunc processTile)
     {
-      // we move in isometric y=const lines starting from the top right of the screen, thus covering the whole screen
-      // we move tile and pixel coords simultaneously to avoid performing mapping coordinates back and forth
-      // movement should be pretty obvious if you understand how isometric grid works
-
-      Point start {WIDTH, -tileHeight};
+      Point start {-tileWidth, -tileHeight};
       auto startingTile = getTileFromScreenCoords(start, toScreen);
 
       auto startingPoint = tileTopPoint(startingTile) + toScreen;
@@ -884,31 +880,23 @@ namespace Render
            auto point = startingPoint;
            auto tile = startingTile;
 
-           // we need to draw object a little bit off screen since object can be staticObjectHeight tall
-           // and still be visible even if placed on tile off the screen. tileWidth / 2 addition is due to
-           // the fact that our point is actually top of tile and it will be completely invisible a bit farther
-           while (point.y < HEIGHT + staticObjectHeight - tileHeight && point.x < WIDTH + tileWidth / 2)
+           while (point.x < WIDTH + tileWidth / 2)
              {
-               point.x += tileWidth / 2;
-               point.y += tileHeight / 2;
+               point.x += tileWidth;
                ++tile.x;
+               --tile.y;
                processTile (tile, point);
              }
         };
 
-      // tile of origin moves from top-right to top left
-      while (startingPoint.x > -tileWidth)
-        {
-          startingPoint.x -= tileWidth;
-          --startingTile.x; ++startingTile.y;
-          processLine ();
-        }
-
       // then from top left to top-bottom
       while (startingPoint.y < HEIGHT + staticObjectHeight - tileHeight)
         {
-          startingPoint.y += tileHeight;
-          ++startingTile.x; ++startingTile.y;
+          ++startingTile.y;
+          startingPoint.x -= tileWidth / 2; startingPoint.y += tileHeight / 2;
+          processLine ();
+          ++startingTile.x;
+          startingPoint.x += tileWidth / 2; startingPoint.y += tileHeight / 2;
           processLine ();
         }
     }

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -557,10 +557,8 @@ namespace Render
 
     void drawAtTile(const Sprite& sprite, const Point& tileTop, int spriteW, int spriteH)
     {
-         int32_t w, h;
-        spriteSize(sprite, w, h);
         // centering spright at the center of tile by width and at the bottom of tile by height
-        drawSprite(sprite, tileTop.x - w / 2, tileTop.y - h + tileHeight);
+        drawSprite(sprite, tileTop.x - spriteW / 2, tileTop.y - spriteH + tileHeight);
     }
 
 
@@ -843,7 +841,7 @@ namespace Render
       return pointA + (pointB - pointA) * (percent * 0.01);
     }
 
-    void drawMovingSprite(const Level::Level& level, const Sprite& sprite, const Tile& start, const Tile& finish, size_t dist, const Vector& toScreen)
+    void drawMovingSprite(const Sprite& sprite, const Tile& start, const Tile& finish, size_t dist, const Vector& toScreen)
     {
         int32_t w, h;
         spriteSize(sprite, w, h);
@@ -853,16 +851,15 @@ namespace Render
     }
 
   constexpr auto bottomMenuSize = 144; // TODO: pass it as a variable
-  Vector worldToScreenVector(const Level::Level& level, const Tile& start, const Tile& finish, size_t dist)
+  Vector worldToScreenVector(const Tile& start, const Tile& finish, size_t dist)
     {
-        auto levelWidth = static_cast<int32_t> (level.width());
         // centering takes in accord bottom menu size to be consistent with original game centering
         return Point{WIDTH / 2, (HEIGHT - bottomMenuSize) / 2} - pointBetween(start, finish, dist);
     }
 
-    Tile getClickedTile(const Level::Level& level, size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist)
+    Tile getClickedTile(size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist)
     {
-        auto toScreen = worldToScreenVector(level, {x1, y1}, {x2, y2}, dist);
+        auto toScreen = worldToScreenVector({x1, y1}, {x2, y2}, dist);
         return getTileFromScreenCoords({static_cast<int32_t> (x), static_cast<int32_t> (y)}, toScreen);
     }
 
@@ -902,7 +899,7 @@ namespace Render
     }
 
     void drawLevel(const Level::Level& level, size_t minTopsHandle, size_t minBottomsHandle, SpriteCacheBase* cache, LevelObjects& objs, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist) {
-      auto toScreen = worldToScreenVector(level, {x1, y1}, {x2, y2}, dist);
+      auto toScreen = worldToScreenVector({x1, y1}, {x2, y2}, dist);
       SpriteGroup* minBottoms = cache->get(minBottomsHandle);
       auto isInvalidTile = [&](const Tile &tile){ return tile.x < 0 || tile.y < 0 || tile.x >= static_cast<int32_t> (level.width()) || tile.y >= static_cast<int32_t> (level.height());};
 
@@ -931,7 +928,7 @@ namespace Render
 
         auto &obj = objs[tile.x][tile.y];
         if (obj.valid)
-           drawMovingSprite(level, (*cache->get(obj.spriteCacheIndex))[obj.spriteFrame], tile, {obj.x2, obj.y2}, obj.dist, toScreen);
+           drawMovingSprite((*cache->get(obj.spriteCacheIndex))[obj.spriteFrame], tile, {obj.x2, obj.y2}, obj.dist, toScreen);
       });
 
       cache->setImmortal(minTopsHandle, false);

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -38,7 +38,7 @@ namespace Render
     RocketSDL2SystemInterface* SystemInterface;
     FAIOFileInterface* FileInterface;
     Rocket::Core::Context* Context;
-    
+
     void init(const RenderSettings& settings)
     {
         WIDTH = settings.windowWidth;
@@ -115,7 +115,7 @@ namespace Render
                 PyRun_SimpleString("import sys\nsys.path.append('./Debug')");
             #endif
         #endif
-        
+
         // add our python libs to path
         PyRun_SimpleString("import sys\nsys.path.append('./resources/python')");
 
@@ -172,7 +172,7 @@ namespace Render
     }
 
 
-    
+
     void quit()
     {
         SDL_DestroyRenderer(renderer);
@@ -262,7 +262,7 @@ namespace Render
         else
         {
             if(celIndex != 0)   // no indices on normal files
-                return false; 
+                return false;
 
             SDL_Surface* surface = loadNonCelImage(path, extension);
 
@@ -507,7 +507,7 @@ namespace Render
             SDL_ShowCursor(0);
             int x,y;
             SDL_GetMouseState(&x,&y);
-            drawAt(s, x-w/2, y-h/2);
+            drawSprite (s, x-w/2, y - h/2);
         }
     }
 
@@ -541,26 +541,33 @@ namespace Render
         SDL_RenderPresent(renderer);
     }
 
-    void drawAt(SDL_Texture* sprite, size_t x, size_t y)
+    void drawSprite(const Sprite &sprite, size_t x, size_t y)
     {
         int width, height;
-        SDL_QueryTexture(sprite, NULL, NULL, &width, &height);
+        auto texture = static_cast<SDL_Texture *> (sprite);
+        SDL_QueryTexture(texture, NULL, NULL, &width, &height);
 
         SDL_Rect dest = { int(x), int(y), width, height };
-        
-        SDL_RenderCopy(renderer, sprite, NULL, &dest);
+
+        SDL_RenderCopy(renderer, texture, NULL, &dest);
     }
-    
-    void drawAt(const Sprite& sprite, size_t x, size_t y)
+
+    constexpr auto tileHeight = 32;
+    constexpr auto tileWidth = tileHeight * 2;
+
+    void drawAtTile(const Sprite& sprite, const Point& tileTop, int spriteW, int spriteH)
     {
-        drawAt((SDL_Texture*)sprite, x, y);
+         int32_t w, h;
+        spriteSize(sprite, w, h);
+        // centering spright at the center of tile by width and at the bottom of tile by height
+        drawSprite(sprite, tileTop.x - w / 2, tileTop.y - h + tileHeight);
     }
 
 
     SpriteGroup::SpriteGroup(const std::string& path)
     {
         Cel::CelFile cel(path);
-        
+
         for(size_t i = 0; i < cel.numFrames(); i++)
         {
             SDL_Surface* s = createTransparentSurface(cel[i].mWidth, cel[i].mHeight);
@@ -614,10 +621,10 @@ namespace Render
         for(size_t i = 0; i < mSprites.size(); i++)
             SDL_DestroyTexture((SDL_Texture*)mSprites[i]);
     }
-    
+
     void drawMinPillarTop(SDL_Surface* s, int x, int y, const std::vector<int16_t>& pillar, Cel::CelFile& tileset);
     void drawMinPillarBase(SDL_Surface* s, int x, int y, const std::vector<int16_t>& pillar, Cel::CelFile& tileset);
-    
+
     SpriteGroup* loadTilesetSprite(const std::string& celPath, const std::string& minPath, bool top)
     {
         Cel::CelFile cel(celPath);
@@ -643,13 +650,10 @@ namespace Render
 
         return new SpriteGroup(newMin);
     }
-    
-    void spriteSize(const Sprite& sprite, size_t& w, size_t& h)
+
+    void spriteSize(const Sprite& sprite, int32_t& w, int32_t& h)
     {
-        int tmpW, tmpH;
-        SDL_QueryTexture((SDL_Texture*)sprite, NULL, NULL, &tmpW, &tmpH);
-        w = tmpW;
-        h = tmpH;
+        SDL_QueryTexture((SDL_Texture*)sprite, NULL, NULL, &w, &h);
     }
 
     void clear(int r, int g, int b)
@@ -663,13 +667,13 @@ namespace Render
 
     void clearTransparentSurface(SDL_Surface* s)
     {
-        SDL_FillRect(s, NULL, SDL_MapRGBA(s->format, 0, 0, 0, 0)); 
+        SDL_FillRect(s, NULL, SDL_MapRGBA(s->format, 0, 0, 0, 0));
     }
 
     SDL_Surface* createTransparentSurface(size_t width, size_t height)
     {
-         SDL_Surface* s; 
-        
+         SDL_Surface* s;
+
         // SDL y u do dis
         #if SDL_BYTEORDER == SDL_BIG_ENDIAN
             s = SDL_CreateRGBSurface(0, width, height, DEPTH, 0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF);
@@ -801,9 +805,9 @@ namespace Render
         {
             int16_t l = (pillar[i]&0x0FFF)-1;
             int16_t r = (pillar[i+1]&0x0FFF)-1;
-            
+
             drawMinTile(s, tileset, x, y, l, r);
-        
+
             y += 32; // down 32 each row
         }
     }
@@ -818,203 +822,129 @@ namespace Render
         drawMinPillar(s, x, y, pillar, tileset, false);
     }
 
-    void drawAt(const Level::Level& level, const Sprite& sprite, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist, int32_t levelX, int32_t levelY)
+    // basic transform of isometric grid to normal, (0, 0) tile coordinate maps to (0, 0) pixel coordinates
+    // since eventually we're gonna shift coordinates to viewport center, it's better to keep transform itself
+    // as simple as possible
+    static Point tileTopPoint (const Tile &tile) {
+      return {(tileWidth / 2) * (tile.x - tile.y), (tile.y + tile.x) * (tileHeight / 2)};
+    }
+
+    // this function simply does the reverse of the above function, could be found by solving linear equation system
+    // it obviously uses the fact that ttileWidth = tileHeight * 2
+    Tile getTileFromScreenCoords(const Point& screenPos, const Vector& toScreen)
     {
-        size_t w, h;
+        auto point = screenPos - toScreen;
+        return {(2 * point.y + point.x) / tileWidth, (2 * point.y - point.x) / tileWidth}; // divisin by 64 is pretty fast btw
+    }
+
+    static Point pointBetween (const Tile &start, const Tile &finish, const size_t &percent) {
+      auto pointA = tileTopPoint (start);
+      auto pointB = tileTopPoint (finish);
+      return pointA + (pointB - pointA) * (percent * 0.01);
+    }
+
+    void drawMovingSprite(const Level::Level& level, const Sprite& sprite, const Tile& start, const Tile& finish, size_t dist, const Vector& toScreen)
+    {
+        int32_t w, h;
         spriteSize(sprite, w, h);
-
-        int32_t xPx1 = ((y1*(-32)) + 32*x1 + level.width()*32) + levelX - w/2;
-        int32_t yPx1 = ((y1*16) + (16*x1) +160) + levelY;
-
-        int32_t xPx2 = ((y2*(-32)) + 32*x2 + level.width()*32) + levelX - w/2;
-        int32_t yPx2 = ((y2*16) + (16*x2) +160) + levelY;
-
-        int32_t x = xPx1 + ((((float)(xPx2-xPx1))/100.0)*(float)dist);
-        int32_t y = yPx1 + ((((float)(yPx2-yPx1))/100.0)*(float)dist);
-
-        drawAt(sprite, x, y);
+        auto point = pointBetween (start, finish, dist);
+        auto res = point + toScreen;
+        drawAtTile(sprite, res, w, h);
     }
 
-    void getMapScreenCoords(const Level::Level& level, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist, int32_t& levelX, int32_t& levelY)
+  constexpr auto bottomMenuSize = 144; // TODO: pass it as a variable
+  Vector worldToScreenVector(const Level::Level& level, const Tile& start, const Tile& finish, size_t dist)
     {
-        int16_t xPx1 = -((y1*(-32)) + 32*x1 + level.width()*32) +WIDTH/2;
-        int16_t yPx1 = -((y1*16) + (16*x1) +160) + HEIGHT/2;
-
-        int16_t xPx2 = -((y2*(-32)) + 32*x2 + level.width()*32) +WIDTH/2;
-        int16_t yPx2 = -((y2*16) + (16*x2) +160) + HEIGHT/2;
-
-        levelX = xPx1 + ((((float)(xPx2-xPx1))/100.0)*(float)dist);
-        levelY = yPx1 + ((((float)(yPx2-yPx1))/100.0)*(float)dist);
+        auto levelWidth = static_cast<int32_t> (level.width());
+        // centering takes in accord bottom menu size to be consistent with original game centering
+        return Point{WIDTH / 2, (HEIGHT - bottomMenuSize) / 2} - pointBetween(start, finish, dist);
     }
 
-    std::pair<int32_t, int32_t> getTileFromScreenCoords(const Level::Level& level, size_t levelX, size_t levelY, size_t x, size_t y)
+    Tile getClickedTile(const Level::Level& level, size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist)
     {
-        // Position on the map in pixels
-        int32_t flatX = x - levelX;
-        int32_t flatY = y - levelY;
+        auto toScreen = worldToScreenVector(level, {x1, y1}, {x2, y2}, dist);
+        return getTileFromScreenCoords({static_cast<int32_t> (x), static_cast<int32_t> (y)}, toScreen);
+    }
 
-        // position on the map divided into 32x16 flat blocks
-        // every second one of these blocks is centred on an isometric
-        // block centre, the others are centred on isometric block corners
-        int32_t flatGridX = (flatX+16) / 32;
-        int32_t flatGridY = (flatY+8) / 16;
-        
-        // origin position (in flat grid coords) for the first line (isometric y = 0)
-        int32_t flatOriginPosX = level.height();
-        int32_t flatOriginPosY = 15;
+    constexpr auto staticObjectHeight = 256;
 
-        // when a flat grid box is clicked that does not centre on an isometric block, work out which
-        // isometric quadrant of that box was clicked, then adjust flatGridPos accordingly
-        if((flatGridX % 2 == 1 && flatGridY % 2 == 1) || (flatGridX % 2 == 0 && flatGridY % 2 == 0))
+    template <typename ProcessTileFunc>
+    void drawObjectsByTiles (const Vector &toScreen, ProcessTileFunc processTile)
+    {
+      // we move in isometric y=const lines starting from the top right of the screen, thus covering the whole screen
+      // we move tile and pixel coords simultaneously to avoid performing mapping coordinates back and forth
+      // movement should be pretty obvious if you understand how isometric grid works
+
+      Point start {WIDTH, -tileHeight};
+      auto startingTile = getTileFromScreenCoords(start, toScreen);
+
+      auto startingPoint = tileTopPoint(startingTile) + toScreen;
+      auto processLine = [&]()
         {
-            
-            // origin of current flat grid box
-            int32_t baseX = 32*flatGridX - 16;
-            int32_t baseY = 16*flatGridY - 8;
-            
-            // position within grid box
-            int32_t blockPosX = flatX - baseX;
-            int32_t blockPosY = flatY - baseY;
+           auto point = startingPoint;
+           auto tile = startingTile;
 
-            if(blockPosY*2 > blockPosX)
-            {
-                if(blockPosX < (15-blockPosY)*2)
-                    flatGridX--;
-                else
-                    flatGridY++;
-            }
-            else
-            {
-                if(blockPosX < (15-blockPosY)*2)
-                    flatGridY--;
-                else
-                    flatGridX++;
-            }
-        }
-        
-        // flatOrigin adjusted for the current y value
-        int32_t lineOriginPosX = flatOriginPosX + ((flatGridX - flatOriginPosX) - (flatGridY - flatOriginPosY))/2;
-        int32_t lineOriginPosY = flatOriginPosY - (-(flatGridX - flatOriginPosX) -( flatGridY - flatOriginPosY))/2;
+           // we need to draw object a little bit off screen since object can be staticObjectHeight tall
+           // and still be visible even if placed on tile off the screen. tileWidth / 2 addition is due to
+           // the fact that our point is actually top of tile and it will be completely invisible a bit farther
+           while (point.y < HEIGHT + staticObjectHeight - tileHeight && point.x < WIDTH + tileWidth / 2)
+             {
+               point.x += tileWidth / 2;
+               point.y += tileHeight / 2;
+               ++tile.x;
+               processTile (tile, point);
+             }
+        };
 
-        int32_t isoPosX = flatGridX - lineOriginPosX;
-        int32_t isoPosY = flatGridY - lineOriginPosY;
-
-        return std::make_pair(isoPosX, isoPosY);
-    }
-    
-    std::pair<int32_t, int32_t> getClickedTile(const Level::Level& level, size_t x, size_t y, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist)
-    {
-        int32_t levelX, levelY;
-        getMapScreenCoords(level, x1, y1, x2, y2, dist, levelX, levelY);
-        
-        return getTileFromScreenCoords(level, levelX, levelY, x, y);
-    }
-    
-    // returns: whether or not to keep drawing the current line (see where it's used for what I mean by "line"
-    bool drawLevelHelper(const Level::Level& level, SpriteGroup& minSprites, int32_t x, int32_t y, int32_t levelX, int32_t levelY)
-    {
-        // if the top left of our screen is on a negative coord (we're at the edge of the map)
-        // we want to continue the line, but we obviously don't want to draw tiles outside the map
-        if(x < 0)
-            return true;
-        
-        if((size_t)x < level.width() && (size_t)y < level.height())
+      // tile of origin moves from top-right to top left
+      while (startingPoint.x > -tileWidth)
         {
-            size_t index = level[x][y].index();
-            int32_t xCoord = (y*(-32)) + 32*x + level.height()*32-32 + levelX;
-            int32_t yCoord = (y*16) + 16*x + levelY;
-
-            if(xCoord <=  WIDTH && yCoord <= HEIGHT)
-            {
-                if(index < minSprites.size())
-                    drawAt(minSprites[index], xCoord, yCoord);
-                
-                return true;
-            }
-            
-            return false;
+          startingPoint.x -= tileWidth;
+          --startingTile.x; ++startingTile.y;
+          processLine ();
         }
-        
-        return false;
+
+      // then from top left to top-bottom
+      while (startingPoint.y < HEIGHT + staticObjectHeight - tileHeight)
+        {
+          startingPoint.y += tileHeight;
+          ++startingTile.x; ++startingTile.y;
+          processLine ();
+        }
     }
 
-    void drawLevel(const Level::Level& level, size_t minTopsHandle, size_t minBottomsHandle, SpriteCacheBase* cache, LevelObjects& objs, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist)
-    {
-        int32_t levelX, levelY;
-        getMapScreenCoords(level, x1, y1, x2, y2, dist, levelX, levelY);
+    void drawLevel(const Level::Level& level, size_t minTopsHandle, size_t minBottomsHandle, SpriteCacheBase* cache, LevelObjects& objs, int32_t x1, int32_t y1, int32_t x2, int32_t y2, size_t dist) {
+      auto toScreen = worldToScreenVector(level, {x1, y1}, {x2, y2}, dist);
+      SpriteGroup* minBottoms = cache->get(minBottomsHandle);
+      auto isInvalidTile = [&](const Tile &tile){ return tile.x < 0 || tile.y < 0 || tile.x >= static_cast<int32_t> (level.width()) || tile.y >= static_cast<int32_t> (level.height());};
 
-        //TODO clean up the magic numbers here, and elsewhere in this file
+      // drawing on the ground objects
+      drawObjectsByTiles (toScreen, [&](const Tile &tile, const Point &topLeft){
+          if (isInvalidTile (tile))
+            return;
 
-        SpriteGroup* minBottoms = cache->get(minBottomsHandle);
-        
-        
-        int32_t startX = WIDTH;
-        int32_t startY = -32;
-        
-        // draw the squares that are in view, starting at the top right of the screen, running
-        // in lines along the isometric x axis until they go off screen, with each line starting one
-        // to the left in screen space (x-1, y+1 in iso space)
-        // this loop draws the bottoms of the tiles, ie the ground, not including walls
-        while(startY < HEIGHT)
-        {
-            std::pair<int32_t, int32_t> tilePos = getTileFromScreenCoords(level, levelX, levelY, startX, startY);
-            
-            while(drawLevelHelper(level, *minBottoms, tilePos.first, tilePos.second, levelX, levelY))
-                tilePos.first++;
-            
-            if(startX > -64)
-            {
-                startX -= 64;
-                
-                if(startX < -64)
-                    startX = -64;
-            }
-            else
-            {
-                startY += 32;
-            }
-        }
-        
-        
-        startX = WIDTH;
-        startY = -256;
-        
-        SpriteGroup* minTops = cache->get(minTopsHandle);
-        cache->setImmortal(minTopsHandle, true);
-        
-        // same as above, but for the above-gound parts (walls + actors)
-        // starts at -256 and finishes at +256 because the minTops are 256 px tall
-        // Note to people trying to improve perf: I tried rolling both loops into one,
-        // the stuff from this loop has to be drawn at y-1 of the stuff from the first loop (or maybe >1)
-        // but it's actually slower. My guess would be that the offset ruins the cache,
-        // so yeah, it's a copy pasted loop DRY blah blah blah
-        while(startY < HEIGHT + 256)
-        {
-            std::pair<int32_t, int32_t> tilePos = getTileFromScreenCoords(level, levelX, levelY, startX, startY);
-            
-            while(drawLevelHelper(level, *minTops, tilePos.first, tilePos.second, levelX, levelY))
-            {
-                if(tilePos.first >= 0 && tilePos.second >= 0 && objs[tilePos.first][tilePos.second].valid)
-                {
-                    LevelObject o = objs[tilePos.first][tilePos.second];
-                    drawAt(level, cache->get(objs[tilePos.first][tilePos.second].spriteCacheIndex)->operator[](o.spriteFrame), tilePos.first, tilePos.second, objs[tilePos.first][tilePos.second].x2, objs[tilePos.first][tilePos.second].y2, objs[tilePos.first][tilePos.second].dist, levelX, levelY);
-                }
-                
-                tilePos.first++;
-            }
-            
-            if(startX > -64)
-            {
-                startX -= 64;
-                
-                if(startX < -64)
-                    startX = -64;
-            }
-            else
-            {
-                startY += 32;
-            }
-        }
-        cache->setImmortal(minTopsHandle, false);
+        size_t index = level[tile.x][tile.y].index();
+        if(index < minBottoms->size())
+           drawAtTile ((*minBottoms)[index], topLeft, tileWidth, staticObjectHeight); // all static objects have the same sprite size
+      });
+
+      SpriteGroup* minTops = cache->get(minTopsHandle);
+      cache->setImmortal(minTopsHandle, true);
+
+      // drawing above the ground and moving object
+      drawObjectsByTiles (toScreen, [&](const Tile &tile, const Point &topLeft){
+        if (isInvalidTile (tile))
+          return;
+
+        size_t index = level[tile.x][tile.y].index();
+        if(index < minTops->size())
+           drawAtTile ((*minTops)[index], topLeft, tileWidth, staticObjectHeight);
+
+        auto &obj = objs[tile.x][tile.y];
+        if (obj.valid)
+           drawMovingSprite(level, (*cache->get(obj.spriteCacheIndex))[obj.spriteFrame], tile, {obj.x2, obj.y2}, obj.dist, toScreen);
+      });
+
+      cache->setImmortal(minTopsHandle, false);
     }
 }


### PR DESCRIPTION
So I started up with the very simple goal in mind to fix viewport centering at 640x480 which was annoying me but since I had to figure out how most of the rendering code works anyway and since I saw issue #149 I decided to rewrite most of it in hopefully more clear way.

1. So the first commit should mostly keep rendering algorithm functionally exactly the same, except maybe be a bit more efficient at certain steps. But it still draws objects in two loops ordered like it was originally.

2. The second commit I'm not actually sure of. I do think that rendering out-of-map tiles should be fixed but I haven't figure out how to find the appropriate tile texture for that. Taking the first one seems to work fine but obviously looks a bit crude. But since it works maybe it's okay to leave it until future better implementation.

3. In the third commit I've changed drawing order to horizontal lines (with new code it wasn't that hard) which may do somehow affect performance but I don't think it's super relevant. It fixed actually very rare and minor glitch for me which I may make gif of if you'd like. The basic problem lies in moving of Actors (even for now it's only player actor which is moving) - since we take into account only starting point of actor's movement in rendering it could lead to things being drawn incorrectly while it still between source and destination tiles.

So for future reference - drawing n moving actors absolutely correctly may require sorting visible actors by their current y screen coordinate and drawing them between corresponding lines of objects in that order. But I'm not sure that it's needed for good visualization or even implemented correctly in Diablo itself so it requires some testing in the future.

PS. I also added some helping structs like `Point`, `Vector`, `Tile` to help me with specifying operations. It's fine to replace them with more generally used versions in the future if there's any, I just didn't find anything similar. Struct `Tile` should technically be in World namespace but in my future commits I had to distinguish between halves of a tile for targeting and it's not required for most of the objects, so maybe `World` needs another `Tile` struct. Anyway I do not think that using `std::pair` for that is a correct decision.