### PR TITLE
Fix some type casting warnings.

### DIFF
--- a/apps/freeablo/engine/enginemain.cpp
+++ b/apps/freeablo/engine/enginemain.cpp
@@ -58,7 +58,7 @@ namespace Engine
 
     void EngineMain::runGameLoop(const bpo::variables_map& variables, const std::string& pathEXE)
     {
-        FALevelGen::FAsrand(time(NULL));
+        FALevelGen::FAsrand(static_cast<int> (time(nullptr)));
 
         FAWorld::Player* player;
         FARender::Renderer& renderer = *FARender::Renderer::get();
@@ -148,11 +148,11 @@ namespace Engine
                 if(!FAGui::cursorPath.empty())
                     state->mCursorEmpty = false;
                 else
-                    state->mCursorEmpty = true;                
+                    state->mCursorEmpty = true;
                 state->mCursorFrame = FAGui::cursorFrame;
-                state->mCursorSpriteGroup = renderer.loadImage("data/inv/objcurs.cel");                
-                world.fillRenderState(state);                
-                Render::updateGuiBuffer(&state->guiDrawBuffer);                
+                state->mCursorSpriteGroup = renderer.loadImage("data/inv/objcurs.cel");
+                world.fillRenderState(state);
+                Render::updateGuiBuffer(&state->guiDrawBuffer);
             }
             else
             {
@@ -160,7 +160,7 @@ namespace Engine
             }
             renderer.setCurrentState(state);
 
-            long remainingTickTime = timer.expires_from_now().total_milliseconds();
+            auto remainingTickTime = timer.expires_from_now().total_milliseconds();
 
             if(remainingTickTime < 0)
                 std::cerr << "tick time exceeded by " << -remainingTickTime << "ms" << std::endl;

--- a/apps/freeablo/engine/threadmanager.cpp
+++ b/apps/freeablo/engine/threadmanager.cpp
@@ -29,7 +29,7 @@ namespace Engine
         FARender::Renderer* renderer = FARender::Renderer::get();
 
         Message message;
-        
+
         auto last = std::chrono::system_clock::now();
         size_t numFrames = 0;
 
@@ -42,12 +42,12 @@ namespace Engine
 
             if(!renderer->renderFrame(mRenderState))
                 break;
-            
+
             auto now = std::chrono::system_clock::now();
             numFrames++;
-            
-            size_t duration = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch() - last.time_since_epoch()).count();
-            
+
+            size_t duration = static_cast<size_t> (std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch() - last.time_since_epoch()).count());
+
             if(duration >= MAXIMUM_DURATION_IN_MS)
             {
                 std::cout << "FPS: " << ((float)numFrames) / (((float)duration)/MAXIMUM_DURATION_IN_MS) << std::endl;

--- a/apps/freeablo/fagui/animateddecorator.cpp
+++ b/apps/freeablo/fagui/animateddecorator.cpp
@@ -40,13 +40,13 @@ namespace FAGui
         vertex.position = Rocket::Core::Vector2f(0, 0);
         vertex.tex_coord = Rocket::Core::Vector2f(0, 0);
         vertices.push_back(vertex);
-        vertex.position = Rocket::Core::Vector2f(0, texDimensions.y);
+        vertex.position = Rocket::Core::Vector2f(0, static_cast<float> (texDimensions.y));
         vertex.tex_coord = Rocket::Core::Vector2f(0, 1);
         vertices.push_back(vertex);
-        vertex.position = Rocket::Core::Vector2f(texDimensions.x, texDimensions.y);
+        vertex.position = Rocket::Core::Vector2f(static_cast<float> (texDimensions.x), static_cast<float> (texDimensions.y));
         vertex.tex_coord = Rocket::Core::Vector2f(1, 1);
         vertices.push_back(vertex);
-        vertex.position = Rocket::Core::Vector2f(texDimensions.x, 0);
+        vertex.position = Rocket::Core::Vector2f(static_cast<float> (texDimensions.x), 0);
         vertex.tex_coord = Rocket::Core::Vector2f(1, 0);
         vertices.push_back(vertex);
 

--- a/apps/freeablo/falevelgen/levelgen.cpp
+++ b/apps/freeablo/falevelgen/levelgen.cpp
@@ -42,7 +42,7 @@ namespace FALevelGen
                 {
                     if((xCoord == x + xPos && yCoord == yPos) ||
                        (xCoord == x + xPos && yCoord == height-1 + yPos))
-                        return true; 
+                        return true;
                     //level[x + room.xPos][room.yPos] = wall;
                     //level[x + room.xPos][room.height-1 + room.yPos] = wall;
                 }
@@ -52,7 +52,7 @@ namespace FALevelGen
                 {
                     if((xCoord == xPos && yCoord == y + yPos) ||
                        (xCoord == width-1 + xPos && yCoord == y + yPos))
-                        return true; 
+                        return true;
 
 
                     //level[room.xPos][y + room.yPos] = wall;
@@ -74,7 +74,7 @@ namespace FALevelGen
 
             size_t distance(const Room& other) const
             {
-                return sqrt((float)((centre().first - other.centre().first)*(centre().first - other.centre().first) + (centre().second - other.centre().second)*(centre().second - other.centre().second)));
+                return static_cast<size_t> (sqrt(static_cast<float>((centre().first - other.centre().first) * (centre().first - other.centre().first) + (centre().second - other.centre().second) * (centre().second - other.centre().second))));
             }
     };
 
@@ -112,7 +112,7 @@ namespace FALevelGen
                 fillRoom(corridoorRooms[i], level);
         }
     }
-    
+
     // Ensures that two points are connected by inserting an l-shaped corridoor,
     // also draws any rooms in rooms vector that the corridoor intersects
     void connect(const Room& a, const Room& b, const std::vector<Room>& rooms, Level::Dun& level)
@@ -122,7 +122,7 @@ namespace FALevelGen
 
         size_t bx = b.centre().first;
         size_t by = b.centre().second;
-        
+
         if(bx != ax)
         {
             if(bx > ax)
@@ -132,7 +132,7 @@ namespace FALevelGen
             }
             else
             {
-                Room x(bx, ay-1, ax-bx, 3); 
+                Room x(bx, ay-1, ax-bx, 3);
                 drawCorridoorSegment(x, rooms, level);
             }
         }
@@ -147,12 +147,12 @@ namespace FALevelGen
             {
                 Room y(bx-1, by, 3, ay-by+2);
                 drawCorridoorSegment(y, rooms, level);
-                
+
             }
 
         }
     }
-   
+
     // Move room in direction specified by normalised vector, making sure to keep within
     // grid of size width * height
     void moveRoom(Room& room, const std::pair<float, float>& vector, size_t width, size_t height)
@@ -220,7 +220,7 @@ namespace FALevelGen
                 assert(false); // This should never happen
             }
         }
-        
+
         int32_t newX = room.xPos + xMove;
         int32_t newY = room.yPos + yMove;
 
@@ -238,7 +238,7 @@ namespace FALevelGen
         vector.first /= (float)magnitude;
         vector.second /= (float)magnitude;
     }
-    
+
     // Removes the room overlapping the largest number of rooms repeatedly,
     // until there are no overlaps
     void removeOverlaps(std::vector<Room>& rooms)
@@ -264,7 +264,7 @@ namespace FALevelGen
                         overlap = true;
                     }
                 }
-                
+
                 if(neighbourCount > maxNeighbourCount)
                 {
                     maxIndex = i;
@@ -276,9 +276,9 @@ namespace FALevelGen
                 rooms.erase(rooms.begin() + maxIndex);
         }
     }
-    
+
     // Separate rooms so they don't overlap, using flocking ai
-    // based on the algorithm described here: 
+    // based on the algorithm described here:
     // http://gamedevelopment.tutsplus.com/tutorials/the-three-simple-rules-of-flocking-behaviors-alignment-cohesion-and-separation--gamedev-3444
     void separate(std::vector<Room>& rooms, size_t width, size_t height)
     {
@@ -294,17 +294,17 @@ namespace FALevelGen
 
             for(size_t i = 0; i < rooms.size(); i++)
             {
-                std::pair<float, float> vector(0, 0);
+                std::pair<float, float> vector(0.f, 0.f);
 
                 std::pair<int32_t, int32_t> currentCentre = rooms[i].centre();
-                
+
                 size_t neighbourCount = 0;
 
                 for(size_t j = 0; j < rooms.size(); j++)
                 {
                     if(i == j)
                         continue;
-                    
+
                     bool intersects = rooms[i].intersects(rooms[j]);
 
                     overlap = overlap || intersects;
@@ -315,12 +315,12 @@ namespace FALevelGen
 
                         if(centre.first == currentCentre.first && centre.second == currentCentre.second)
                         {
-                            vector.first = randomInRange(0, 10);
-                            vector.second = randomInRange(0, 10);
+                            vector.first = static_cast<float> (randomInRange(0, 10));
+                            vector.second = static_cast<float> (randomInRange(0, 10));
                             neighbourCount++;
                             continue;
                         }
-                        
+
                         std::pair<float, float> iToJ = Misc::getVec(currentCentre, centre);
                         normalise(iToJ);
 
@@ -333,23 +333,23 @@ namespace FALevelGen
 
                 if(vector.first == 0 && vector.second == 0)
                     continue;
-               
+
                 vector.first /= (float)neighbourCount;
                 vector.second /= (float)neighbourCount;
 
                 normalise(vector);
-                
+
                 // invert
                 vector.first *= -1;
                 vector.second *= -1;
-                
+
                 moveRoom(rooms[i], vector, width, height);
             }
 
         }
-        
+
         if(overlap)
-            removeOverlaps(rooms);    
+            removeOverlaps(rooms);
     }
 
     void generateRooms(std::vector<Room>& rooms, size_t width, size_t height)
@@ -360,11 +360,11 @@ namespace FALevelGen
 
         size_t centreX = width/2;
         size_t centreY = height/2;
-       
+
         // The following two are based on the fact that 150 rooms in a radius of
-        // 15 looks good on an 85*75 map 
-        size_t numRooms = std::min(width, height)*(150.0/75.0);
-        size_t radius = std::min(width, height)*(15.0/75.0);
+        // 15 looks good on an 85*75 map
+        size_t numRooms = static_cast<size_t> (std::min(width, height)*(150.0/75.0));
+        size_t radius = static_cast<size_t> (std::min(width, height)*(15.0/75.0));
 
         while(placed < numRooms)
         {
@@ -372,10 +372,10 @@ namespace FALevelGen
 
             if(((centreX-newRoom.centre().first)*(centreX-newRoom.centre().first) + (centreY-newRoom.centre().second)*(centreY-newRoom.centre().second)) > radius*radius)
                 continue;
-            
+
             newRoom.width = normRand(4, std::min(width-newRoom.xPos, maxDimension));
             newRoom.height = normRand(4, std::min(height-newRoom.yPos, maxDimension));
-            
+
             float ratio = ((float)newRoom.width) / ((float)newRoom.height);
 
             if(ratio < 0.5 || ratio > 2.0)
@@ -403,7 +403,7 @@ namespace FALevelGen
             level[room.xPos][y + room.yPos] = wall;
             level[room.width-1 + room.xPos][y + room.yPos] = wall;
         }
-        
+
         // Fill ground
         for(size_t x = 1; x < room.width-1; x++)
         {
@@ -413,16 +413,16 @@ namespace FALevelGen
             }
         }
     }
-    
+
     // Get the value at (x,y) in level, or zero if it is an invalid position
     size_t getXY(int32_t x, int32_t y, const Level::Dun& level)
     {
         if(x < 0 || x >= (int32_t)level.width() || y < 0 || y >= (int32_t)level.height())
             return 0;
-        
+
         return level[x][y];
     }
-    
+
     // Returns true if the tile at (x,y) in level borders any tile of the value tile,
     // false otherwise
     bool borders(size_t x, size_t y, Basic tile, const Level::Dun& level)
@@ -433,12 +433,12 @@ namespace FALevelGen
             {
                 int32_t testX = xoffs + x;
                 int32_t testY = yoffs + y;
-                
+
                 if(getXY(testX, testY, level) == tile)
                     return true;
             }
         }
-        
+
         return false;
     }
 
@@ -560,7 +560,7 @@ namespace FALevelGen
             }
         }
     }
-    
+
     // Remove double walls, as the tileset does not allow for them
     void cleanup(Level::Dun& level, std::vector<Room>& rooms)
     {
@@ -577,7 +577,7 @@ namespace FALevelGen
 
         cleanLooseWalls(level, false);
     }
-    
+
     // Helper function for adding doors
     // Iterates over all blocks on a wall, and adds doors where necessary, looking at what is in the direction
     // indicated by add (1 or -1) to determine if a door is needed
@@ -589,13 +589,13 @@ namespace FALevelGen
 
         for(size_t i = start; i < end; i++)
         {
-            if((xAxis && (getXY(i, otherCoord, level) == floor || getXY(i, otherCoord, level) == door)) || 
+            if((xAxis && (getXY(i, otherCoord, level) == floor || getXY(i, otherCoord, level) == door)) ||
               (!xAxis && (getXY(otherCoord, i, level) == floor || getXY(otherCoord, i, level) == door)))
             {
                 hole = true;
             }
             else if((xAxis && getXY(i, otherCoord+add, level) != floor) ||
-                   (!xAxis && getXY(otherCoord+add, i, level) != floor)) 
+                   (!xAxis && getXY(otherCoord+add, i, level) != floor))
             {
                 if(hole)
                     region.resize(0);
@@ -611,12 +611,12 @@ namespace FALevelGen
                     {
                         if(region.size() > 0)
                             level[region[region.size()/2].first][region[region.size()/2].second] = door;
-                        
+
                         region.resize(0);
                         connected = true;
                     }
-                    
-                    if(xAxis) 
+
+                    if(xAxis)
                     {
                         if(getXY(i-1, otherCoord, level) == wall && getXY(i+1, otherCoord, level) == wall)
                             region.push_back(std::pair<size_t, size_t>(i, otherCoord));
@@ -633,24 +633,24 @@ namespace FALevelGen
                 }
             }
         }
-        
+
         if(!hole && region.size() > 0)
             level[region[region.size()/2].first][region[region.size()/2].second] = (levelNum == 4) ? floor : door;
     }
-    
+
     void addDoors(Level::Dun& level, const std::vector<Room>& rooms, size_t levelNum)
     {
         for(size_t i = 0; i < rooms.size(); i++)
         {
             // Top x wall
-            doorAddHelper(level, rooms[i].yPos,                   -1, rooms[i].xPos+1, rooms[i].xPos + rooms[i].width -1,  true, levelNum); 
+            doorAddHelper(level, rooms[i].yPos,                   -1, rooms[i].xPos+1, rooms[i].xPos + rooms[i].width -1,  true, levelNum);
             // Bottom x wall
-            doorAddHelper(level, rooms[i].yPos+rooms[i].height-1, +1, rooms[i].xPos+1, rooms[i].xPos + rooms[i].width -1,  true, levelNum); 
-            
+            doorAddHelper(level, rooms[i].yPos+rooms[i].height-1, +1, rooms[i].xPos+1, rooms[i].xPos + rooms[i].width -1,  true, levelNum);
+
             // Left y wall
-            doorAddHelper(level, rooms[i].xPos,                   -1, rooms[i].yPos+1, rooms[i].yPos + rooms[i].height -1, false, levelNum); 
+            doorAddHelper(level, rooms[i].xPos,                   -1, rooms[i].yPos+1, rooms[i].yPos + rooms[i].height -1, false, levelNum);
             // Right y wall
-            doorAddHelper(level, rooms[i].xPos+rooms[i].width-1,  +1, rooms[i].yPos+1, rooms[i].yPos + rooms[i].height -1, false, levelNum); 
+            doorAddHelper(level, rooms[i].xPos+rooms[i].width-1,  +1, rooms[i].yPos+1, rooms[i].yPos + rooms[i].height -1, false, levelNum);
         }
     }
 
@@ -662,8 +662,8 @@ namespace FALevelGen
             {
                 size_t baseX = rooms[i].xPos + (rooms[i].width/2);
                 size_t baseY = rooms[i].yPos;
-                
-                // on a wall       
+
+                // on a wall
                 if(level[baseX-1][baseY-2] == blank && level[baseX][baseY-2] == blank && level[baseX+1][baseY-2] == blank &&
                    level[baseX-1][baseY-1] == blank && level[baseX][baseY-1] == blank && level[baseX+1][baseY-1] == blank &&
                    level[baseX-1][baseY] == wall && level[baseX][baseY] == wall && level[baseX+1][baseY] == wall &&
@@ -687,12 +687,12 @@ namespace FALevelGen
                         continue;
 
                     level[baseX][baseY] = upStairs;
-                    
+
                     return true;
                 }
             }
         }
-            
+
 
         return false;
     }
@@ -728,7 +728,7 @@ namespace FALevelGen
                         continue;
 
                 level[baseX][baseY] = downStairs;
-                
+
                 return true;
             }
         }
@@ -737,24 +737,24 @@ namespace FALevelGen
     }
 
     #define ROOMAREA 30
-    
+
     // Generates a flat map (no information about wall direction, etc)
     // Uses the tinykeep level generation algorithm, described here:
     // http://www.reddit.com/r/gamedev/comments/1dlwc4/procedural_dungeon_generation_algorithm_explained/
     // The basic algorithm is as follows:
-    //     1. Generate a bunch of rooms in a radius around the centre of the map, with rooms weighted 
+    //     1. Generate a bunch of rooms in a radius around the centre of the map, with rooms weighted
     //        towards being small more often than large.
     //     2. Use separation steering to spread them out until they no longer overlap.
     //     3. Split the rooms into two types, real rooms, and corridoor rooms, where real rooms are rooms
     //        with an area above a certain threshold, and corridoor rooms are the rest.
     //     4. Construct a minimum spanning tree which connects all the rooms together, then add in some
     //        extra edges to allow for some loops.
-    //     5. Connect the rooms according to the graph from the last step with l shaped corridoors, and 
+    //     5. Connect the rooms according to the graph from the last step with l shaped corridoors, and
     //        also draw any corridoor rooms that the corridoors overlap as part of the corridoor.
     Level::Dun generateTmp(size_t width, size_t height, size_t levelNum)
     {
         Level::Dun level(width, height);
-        
+
         // Initialise whole dungeon to blank
         for(size_t x = 0; x < width; x++)
             for(size_t y = 0; y < height; y++)
@@ -763,7 +763,7 @@ namespace FALevelGen
         std::vector<Room> rooms;
         std::vector<Room> corridoorRooms;
         generateRooms(rooms, width, height);
-        
+
         // Split rooms into real rooms, and corridoor rooms
         for(size_t i = 0; i < rooms.size(); i++)
         {
@@ -774,7 +774,7 @@ namespace FALevelGen
                 i--;
             }
         }
-        
+
         // Create graph with edge from each room to each other room
         std::vector<std::vector<size_t> > graph(rooms.size());
         for(size_t i = 0; i < rooms.size(); i++)
@@ -790,33 +790,33 @@ namespace FALevelGen
         minimumSpanningTree(graph, parent);
         for(size_t i = 1; i < rooms.size(); i++)
             connect(rooms[parent[i]], rooms[i], corridoorRooms, level);
-        
+
         // Add in an extra 15% of the number of rooms random connections to create some loops
-        size_t fifteenPercent = (((float)rooms.size())/100.0)*15.0;
+        size_t fifteenPercent = static_cast<size_t> (((rooms.size())/100.0)*15.0);
         for(size_t i = 0; i < fifteenPercent; i++)
         {
             size_t a, b;
-            
+
             do
             {
                 a = randomInRange(0, rooms.size()-1);
                 b = randomInRange(0, rooms.size()-1);
             }
             while(a == b || parent[a] == b || parent[b] == a);
-            
+
             connect(rooms[a], rooms[b], corridoorRooms, level);
         }
 
         // Draw rooms on top of corridoors
         for(size_t i = 0; i < rooms.size(); i++)
             drawRoom(rooms[i], level);
-        
+
         // Bound corridoors with walls
         addWalls(level);
 
-        cleanup(level, rooms); 
+        cleanup(level, rooms);
         addDoors(level, rooms, levelNum);
-        
+
         // Make sure we always place stairs
         if(!(placeUpStairs(level, rooms, levelNum) && placeDownStairs(level, rooms, levelNum)))
             return generateTmp(width, height, levelNum);
@@ -840,13 +840,13 @@ namespace FALevelGen
     {
         return getXY(x, y, tmpLevel) == floor || getXY(x, y, tmpLevel) == door;
     }
- 
+
     void setPoint(int32_t x, int32_t y, size_t val, const Level::Dun& tmpLevel,  Level::Dun& level, int32_t wallOffset, bool isInsideWall)
     {
         size_t newVal = val;
 
         if(val == (size_t)TileSetEnum::xWall+wallOffset)
-        {   
+        {
             if(getXY(x, y, tmpLevel) == door && isInsideWall)
                 newVal = TileSetEnum::xDoor;
             else if(getXY(x, y, tmpLevel) == upStairs)
@@ -864,7 +864,7 @@ namespace FALevelGen
         }
 
         else if(val == (size_t)TileSetEnum::yWall+wallOffset)
-        {   
+        {
             if(getXY(x, y, tmpLevel) == door && isInsideWall)
                 newVal = TileSetEnum::yDoor;
             else if(!isInsideWall && getXY(x+1, y, tmpLevel) == blank)
@@ -908,11 +908,11 @@ namespace FALevelGen
 
         level[x][y] = newVal;
     }
-    
+
     void placeMonsters(Level::Level& level, std::vector<FAWorld::Actor*>& actors, const DiabloExe::DiabloExe& exe, size_t dLvl)
     {
         std::vector<const DiabloExe::Monster*> possibleMonsters = exe.getMonstersInLevel(dLvl);
-        
+
         for(size_t i = 0; i < (level.height() + level.width())/2; i++)
         {
             size_t xPos, yPos;
@@ -1114,7 +1114,7 @@ namespace FALevelGen
         }
     }
 
- 
+
     FAWorld::GameLevel* generate(size_t width, size_t height, size_t dLvl, const DiabloExe::DiabloExe& exe, size_t previous, size_t next)
     {
         size_t levelNum = ((dLvl-1) / 4) + 1;
@@ -1152,7 +1152,7 @@ namespace FALevelGen
                     level[x][y] = tileset.convert(((TileSetEnum::TileSetEnum)level[x][y]));
             }
         }
-        
+
         // Add in some random aesthetic variation
         for(int32_t x = 0; x < (int32_t)width; x++)
         {
@@ -1198,7 +1198,7 @@ namespace FALevelGen
             level[x][y+1] = tileset.downStairs8;
             level[x+1][y+1] = tileset.downStairs9;
         }
-        
+
         ss.str(""); ss << "levels/l" << levelNum << "data/l" << levelNum << ".cel";
         std::string celPath = ss.str();
 
@@ -1210,7 +1210,7 @@ namespace FALevelGen
 
         ss.str(""); ss << "levels/l" << levelNum << "data/l" << levelNum << ".sol";
         std::string solPath = ss.str();
-                
+
         Level::Level retval(level, tilPath, minPath, solPath, celPath, downStairsPoint, upStairsPoint, tileset.getDoorMap(), previous, next);
 
         std::vector<FAWorld::Actor*> actors;

--- a/apps/freeablo/falevelgen/random.cpp
+++ b/apps/freeablo/falevelgen/random.cpp
@@ -9,7 +9,7 @@ namespace FALevelGen
     {
         rng.seed(seed);
     }
-    
+
     int normRand(int min, int max)
     {
         std::normal_distribution<> nd(min, (float)(max-min)/3.5);
@@ -17,7 +17,7 @@ namespace FALevelGen
         int result;
         do
         {
-            result = nd(rng);
+            result = static_cast<int> (nd(rng));
         }
         while(result < min || result > max);
 

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -21,7 +21,7 @@ namespace FAWorld
             size_t animDivisor = mAnimTimeMap[getAnimState()];
             if (animDivisor == 0)
             {
-                animDivisor = FAWorld::World::getTicksInPeriod(0.1);
+                animDivisor = FAWorld::World::getTicksInPeriod(0.1f);
             }
             bool advanceAnims = !(ticksPassed % (World::ticksPerSecond / animDivisor));
 
@@ -158,8 +158,8 @@ namespace FAWorld
         if (!idleAnimPath.empty())
             mIdleAnim = FARender::Renderer::get()->loadImage(idleAnimPath);
         mDestination = mPos.current();
-        mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1);
-        mAnimTimeMap[AnimState::walk] = FAWorld::World::getTicksInPeriod(0.1);
+        mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1f);
+        mAnimTimeMap[AnimState::walk] = FAWorld::World::getTicksInPeriod(0.1f);
 
         mId = getNewId();
     }
@@ -172,7 +172,7 @@ namespace FAWorld
 
     void Actor::takeDamage(double amount)
     {
-        mStats->takeDamage(amount);
+        mStats->takeDamage(static_cast<int32_t> (amount));
         if (!(mStats->getCurrentHP() <= 0))
         {
             Engine::ThreadManager::get()->playSound(getHitWav());

--- a/apps/freeablo/faworld/characterstats.cpp
+++ b/apps/freeablo/faworld/characterstats.cpp
@@ -332,8 +332,8 @@ namespace FAWorld
         mMagic += mStartingMagic + mSpentLevelsOnMagic;
         mDexterity += mStartingDexterity + mSpentLevelsOnDexterity;
         mVitality += mStartingVitality + mSpentLevelsOnVitality;
-        mHP += mVitality + 1.5*mBonusVitality + 2*mLevel + 23;
-        mMana += mMagic + 1.5*mBonusMagic + 2*mLevel + 5;
+        mHP += static_cast<uint32_t> (mVitality + 1.5*mBonusVitality + 2*mLevel + 23);
+        mMana += static_cast<uint32_t> (mMagic + 1.5*mBonusMagic + 2*mLevel + 5);
         mArmourClass += mDexterity/5;
         mDamageDoneBow += ((mStrength + mDexterity) * mLevel)/100;
         mDamageDoneMelee += ((mStrength + mDexterity) * mLevel)/200.0;

--- a/apps/freeablo/faworld/item.cpp
+++ b/apps/freeablo/faworld/item.cpp
@@ -87,8 +87,8 @@ Item::Item(DiabloExe::BaseItem item, uint32_t id, DiabloExe::Affix* affix, bool 
 
         mGraphicValue +=11;
         Cel::CelFrame frame = (*mObjcurs)[mGraphicValue];
-        mSizeX = frame.mWidth/28;
-        mSizeY = frame.mHeight/28;
+        mSizeX = static_cast<uint8_t> (frame.mWidth/28);
+        mSizeY = static_cast<uint8_t> (frame.mHeight/28);
         mMaxCount = 1;
         mCount=1;
     }

--- a/apps/freeablo/faworld/itemmanager.cpp
+++ b/apps/freeablo/faworld/itemmanager.cpp
@@ -34,7 +34,7 @@ void ItemManager::loadItems(DiabloExe::DiabloExe * exe)
         std::map<std::string, DiabloExe::BaseItem> itemMap = exe->getItemMap();
         for(std::map<std::string, DiabloExe::BaseItem>::const_iterator it = itemMap.begin();it !=itemMap.end();++it)
         {
-            this->mRegisteredItems[this->mRegisteredItems.size()] = Item(it->second, mRegisteredItems.size());
+            this->mRegisteredItems[static_cast<uint8_t> (this->mRegisteredItems.size())] = Item(it->second, mRegisteredItems.size());
             if(it->second.uniqCode !=0)
                 this->mUniqueCodeToBaseItem[it->second.uniqCode] = it->second;
 
@@ -50,7 +50,7 @@ void ItemManager::loadUniqueItems(DiabloExe::DiabloExe * exe)
         const std::map<std::string, DiabloExe::UniqueItem>& uniqueItemMap = exe->getUniqueItemMap();
         for(std::map<std::string, DiabloExe::UniqueItem>::const_iterator it = uniqueItemMap.begin();it !=uniqueItemMap.end();++it)
         {
-            this->mUniqueItems[this->mUniqueItems.size()] = Item(it->second, mUniqueItems.size());
+            this->mUniqueItems[static_cast<uint8_t> (this->mUniqueItems.size())] = Item(it->second, mUniqueItems.size());
 
 
 

--- a/apps/freeablo/faworld/monster.cpp
+++ b/apps/freeablo/faworld/monster.cpp
@@ -16,10 +16,10 @@ namespace FAWorld
 
     void Monster::init()
     {
-        mAnimTimeMap[AnimState::dead] = FAWorld::World::getTicksInPeriod(0.1);
-        mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1);
-        mAnimTimeMap[AnimState::dead] = FAWorld::World::getTicksInPeriod(0.1);
-        mAnimTimeMap[AnimState::hit] = FAWorld::World::getTicksInPeriod(0.1);
+        mAnimTimeMap[AnimState::dead] = FAWorld::World::getTicksInPeriod(0.1f);
+        mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1f);
+        mAnimTimeMap[AnimState::dead] = FAWorld::World::getTicksInPeriod(0.1f);
+        mAnimTimeMap[AnimState::hit] = FAWorld::World::getTicksInPeriod(0.1f);
 
         mIsEnemy = true;
     }

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -16,7 +16,7 @@ namespace FAWorld
         DiabloExe::CharacterStats stats;
         init("Warrior", stats);
     }
-    
+
     Player::Player(const std::string& className, const DiabloExe::CharacterStats& charStats) : Actor(), mInventory(this)
     {
         init(className, charStats);
@@ -30,14 +30,14 @@ namespace FAWorld
             mStats = new FAWorld::RangerStats(charStats, this);
         else if (className == "Sorcerer")
             mStats = new FAWorld::MageStats(charStats, this);
-        
+
         mStats->setActor(this);
         mStats->recalculateDerivedStats();
-        
-        mAnimTimeMap[AnimState::dead] = FAWorld::World::getTicksInPeriod(0.1);
-        mAnimTimeMap[AnimState::walk] = FAWorld::World::getTicksInPeriod(0.1);
-        mAnimTimeMap[AnimState::attack] = FAWorld::World::getTicksInPeriod(0.2);
-        mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1);
+
+        mAnimTimeMap[AnimState::dead] = FAWorld::World::getTicksInPeriod(0.1f);
+        mAnimTimeMap[AnimState::walk] = FAWorld::World::getTicksInPeriod(0.1f);
+        mAnimTimeMap[AnimState::attack] = FAWorld::World::getTicksInPeriod(0.2f);
+        mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1f);
 
         FAWorld::World::get()->registerPlayer(this);
     }
@@ -96,7 +96,7 @@ namespace FAWorld
     }
 
     FARender::FASpriteGroup* Player::getCurrentAnim()
-    {       
+    {
         auto lastClassName = mFmtClassName;
         auto lastClassCode = mFmtClassCode;
         auto lastArmourCode = mFmtArmourCode;

--- a/apps/freeablo/faworld/position.cpp
+++ b/apps/freeablo/faworld/position.cpp
@@ -17,7 +17,7 @@ namespace FAWorld
     {
         if (mMoving)
         {
-            mDist += FAWorld::World::getSecondsPerTick() * 250;
+            mDist += static_cast<int32_t> (FAWorld::World::getSecondsPerTick() * 250);
 
             if (mDist >= 100)
             {

--- a/components/cel/celdecoder.cpp
+++ b/components/cel/celdecoder.cpp
@@ -206,10 +206,10 @@ namespace Cel
                     return;
                 }
 
-                mFrames.push_back(std::vector<uint8_t>(frameSize));
+                mFrames.push_back(std::vector<uint8_t>(static_cast<size_t> (frameSize)));
                 uint32_t idx = mFrames.size() - 1;
                 file.FAfseek(mHeaderSize, SEEK_CUR);
-                file.FAfread(&mFrames[idx][0], 1, frameSize);
+                file.FAfread(&mFrames[idx][0], 1, static_cast<size_t> (frameSize));
             }
 
             mAnimationLength = frameCount;

--- a/components/faio/faio.cpp
+++ b/components/faio/faio.cpp
@@ -24,14 +24,14 @@ namespace FAIO
     std::string getStormLibPath(const bfs::path& path)
     {
         std::string retval = "";
-        
+
         for(bfs::path::iterator it = path.begin(); it != path.end(); ++it)
         {
             retval += it->string() + "\\";
         }
-        
+
         retval = retval.substr(0, retval.size()-1);
-        
+
         return retval;
     }
 
@@ -86,7 +86,7 @@ namespace FAIO
                 std::cerr << "File " << path << " not found" << std::endl;
                 return NULL;
             }
-            
+
             FAFile* file = new FAFile();
             file->data.mpqFile = malloc(sizeof(HANDLE));
 
@@ -108,7 +108,7 @@ namespace FAIO
                 return NULL;
 
             FAFile* file = new FAFile();
-            file->mode = FAFile::PlainFile; 
+            file->mode = FAFile::PlainFile;
             file->data.plainFile.file = plainFile;
             file->data.plainFile.filename = new std::string(filename);
 
@@ -122,7 +122,7 @@ namespace FAIO
         {
             case FAFile::PlainFile:
                 return fread(ptr, size, count, stream->data.plainFile.file);
-            
+
             case FAFile::MPQFile:
             {
                 std::lock_guard<std::mutex> lock(m);
@@ -146,7 +146,7 @@ namespace FAIO
         }
         return 0;
     }
-    
+
     int FAfclose(FAFile* stream)
     {
         int retval = 0;
@@ -185,12 +185,12 @@ namespace FAIO
         {
             case FAFile::PlainFile:
                 return fseek(stream->data.plainFile.file, offset, origin);
-            
+
             case FAFile::MPQFile:
             {
                 std::lock_guard<std::mutex> lock(m);
                 DWORD moveMethod;
-                
+
                 switch(origin)
                 {
                     case SEEK_SET:
@@ -204,7 +204,7 @@ namespace FAIO
                     case SEEK_END:
                         moveMethod = FILE_END;
                         break;
-                    
+
                     default:
                         return 1; // error, incorrect origin
                 }
@@ -243,7 +243,7 @@ namespace FAIO
         switch(stream->mode)
         {
             case FAFile::PlainFile:
-                return bfs::file_size(*(stream->data.plainFile.filename));
+                return static_cast<size_t> (bfs::file_size(*(stream->data.plainFile.filename)));
 
             case FAFile::MPQFile:
             {
@@ -252,7 +252,7 @@ namespace FAIO
             }
         }
 
-        return 0; 
+        return 0;
     }
 
     uint32_t read32(FAFile* file)
@@ -279,7 +279,7 @@ namespace FAIO
     std::string readCString(FAFile* file, size_t ptr)
     {
         std::string retval = "";
-        
+
         if(ptr)
         {
             FAfseek(file, ptr, SEEK_SET);
@@ -308,7 +308,7 @@ namespace FAIO
     std::string getMPQFileName()
     {
 		bfs::directory_iterator end;
-		for(bfs::directory_iterator entry(".") ; entry != end; entry++) 
+		for(bfs::directory_iterator entry(".") ; entry != end; entry++)
 		{
 			if (!bfs::is_directory(*entry))
 			{

--- a/components/level/dun.cpp
+++ b/components/level/dun.cpp
@@ -10,15 +10,17 @@ namespace Level
     Dun::Dun(const std::string& filename)
     {
         FAIO::FAFileObject f(filename);
-        
-        int16_t temp;        
+
+        int16_t temp;
         f.FAfread(&temp, 2, 1);
         mWidth = temp;
         f.FAfread(&temp, 2, 1);
         mHeight = temp;
-       
-        mBlocks.resize(mWidth*mHeight);
-        f.FAfread(&mBlocks[0], 2, mWidth*mHeight);
+
+        std::vector<int16_t> buf (mWidth*mHeight);
+        f.FAfread(buf.data (), 2, mWidth*mHeight);
+        mBlocks.resize(buf.size ());
+        std::copy (buf.begin (), buf.end (), mBlocks.begin ());
 
         std::cout << "w: " << mWidth << ", h: " << mHeight << std::endl;
     }
@@ -34,13 +36,13 @@ namespace Level
     {
         mWidth = width;
         mHeight = height;
-        mBlocks.resize(mWidth*mHeight, 0);    
+        mBlocks.resize(mWidth*mHeight, 0);
     }
 
     Dun Dun::getTown(const Dun& sector1, const Dun& sector2, const Dun& sector3, const Dun& sector4)
     {
         Dun town(48, 48);
-        
+
         for(size_t x = 0; x < sector3.mWidth; x++)
         {
             for(size_t y = 0; y < sector3.mHeight; y++)
@@ -76,24 +78,24 @@ namespace Level
         return town;
     }
 
-    int16_t& get(size_t x, size_t y, Dun& dun)
+    size_t& get(size_t x, size_t y, Dun& dun)
     {
         return dun.mBlocks[x+y*dun.width()];
     }
 
-    const int16_t& get(size_t x, size_t y, const Dun& dun)
+    const size_t& get(size_t x, size_t y, const Dun& dun)
     {
         return dun.mBlocks[x+y*dun.width()];
     }
 
-    Misc::Helper2D<Dun, int16_t&> Dun::operator[] (size_t x)
+    Misc::Helper2D<Dun, size_t&> Dun::operator[] (size_t x)
     {
-        return Misc::Helper2D<Dun, int16_t&>(*this, x, get);
+        return Misc::Helper2D<Dun, size_t&>(*this, x, get);
     }
 
-    Misc::Helper2D<const Dun, const int16_t&> Dun::operator[] (size_t x) const
+    Misc::Helper2D<const Dun, const size_t&> Dun::operator[] (size_t x) const
     {
-        return Misc::Helper2D<const Dun, const int16_t&>(*this, x, get);
+        return Misc::Helper2D<const Dun, const size_t&>(*this, x, get);
     }
 
     size_t Dun::width() const

--- a/components/level/dun.h
+++ b/components/level/dun.h
@@ -19,24 +19,24 @@ namespace Level
             Dun(const std::string&);
             Dun();
             Dun(size_t width, size_t height);
-            
+
             static Dun getTown(const Dun& sector1, const Dun& sector2, const Dun& sector3, const Dun& sector4);
 
-            Misc::Helper2D<Dun, int16_t&> operator[] (size_t x);
-            Misc::Helper2D<const Dun, const int16_t&> operator[] (size_t x) const;
+            Misc::Helper2D<Dun, size_t&> operator[] (size_t x);
+            Misc::Helper2D<const Dun, const size_t&> operator[] (size_t x) const;
 
             size_t width() const;
             size_t height() const;
-            
+
         private:
             void resize(size_t width, size_t height);
 
-            std::vector<int16_t> mBlocks;
+            std::vector<size_t> mBlocks;
             size_t mWidth;
             size_t mHeight;
 
-            friend const int16_t& get(size_t x, size_t y, const Dun& dun);
-            friend int16_t& get(size_t x, size_t y, Dun& dun);
+            friend const size_t& get(size_t x, size_t y, const Dun& dun);
+            friend size_t& get(size_t x, size_t y, Dun& dun);
 
             friend class boost::serialization::access;
 

--- a/components/misc/misc.cpp
+++ b/components/misc/misc.cpp
@@ -12,8 +12,8 @@ namespace Misc
     {
         if(vector.first == 0 && vector.second == 0)
             return -1;
-        
-        float angle = (std::atan2(vector.second, vector.first) / M_PI) * 180.0;
+
+        auto angle = (std::atan2(vector.second, vector.first) / M_PI) * 180.0;
 
         if(angle < 0)
             angle = 360 + angle;

--- a/components/render/rocketglue/SystemInterfaceSDL2.cpp
+++ b/components/render/rocketglue/SystemInterfaceSDL2.cpp
@@ -14,7 +14,7 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,7 +33,7 @@
 
 float RocketSDL2SystemInterface::GetElapsedTime()
 {
-	return (float)SDL_GetTicks() / 1000.0;
+	return SDL_GetTicks() / 1000.0f;
 }
 
 bool RocketSDL2SystemInterface::LogMessage(Rocket::Core::Log::Type type, const Rocket::Core::String& message)

--- a/components/serial/bitstream.cpp
+++ b/components/serial/bitstream.cpp
@@ -62,7 +62,7 @@ namespace Serial
     WriteBitStream::WriteBitStream(std::vector<uint8_t>& resizeableBacking)
     {
         mResizableBacking = &resizeableBacking;
-        
+
         if (mResizableBacking->size() == 0)
             mResizableBacking->resize(1, 0); // make sure we have a bit of space at least so the old &vec[0] trick works
 
@@ -78,7 +78,7 @@ namespace Serial
 
         if (byteSize > mResizableBacking->size())
         {
-            mResizableBacking->resize(byteSize, 0);
+            mResizableBacking->resize(static_cast<size_t> (byteSize), 0);
             mSize = byteSize * 8;
             mData = &(*mResizableBacking)[0];
         }
@@ -217,8 +217,8 @@ namespace Serial
             done++;
         }
 
-        size_t bytePos = mCurrentPos / 8;
-        size_t byteSize = mSize / 8;
+        size_t bytePos = static_cast<size_t> (mCurrentPos) / 8;
+        size_t byteSize = static_cast<size_t> (mSize) / 8;
 
         memset(&mData[bytePos], 0, byteSize - bytePos);
     }
@@ -239,8 +239,8 @@ namespace Serial
             done++;
         }
 
-        size_t bytePos = mCurrentPos / 8;
-        size_t byteSize = mSize / 8;
+        size_t bytePos = static_cast<size_t> (mCurrentPos) / 8;
+        size_t byteSize = static_cast<size_t> (mSize) / 8;
 
         for (size_t i = bytePos; i < byteSize; i++)
         {


### PR DESCRIPTION
Mostly this commit straightforwardly adds casts in the places where Visual Studio complains about `loss of information`. It shouldn't do any functional change for the most part. However I changed `Dun` class to store `std::size_t` instead of `int16_t`  because it had just a ton of casts backwards and forwards from `size_t`.  And I don't think it's necessary to store numbers in the same way they were stored in binary if we have to cast them each time anyway.