### PR TITLE
Actor hover

### DIFF
--- a/apps/findpath/main.cpp
+++ b/apps/findpath/main.cpp
@@ -46,6 +46,11 @@ namespace FAWorld
             return gameMap[y][x] == 0 ? true : false;
         }
 
+        bool isPassableFor(int x, int y, const Actor *) const override
+        {
+            return isPassable (x, y);
+        }
+
     private:
         int gameMap[MAP_SIZE][MAP_SIZE];
 

--- a/apps/freeablo/CMakeLists.txt
+++ b/apps/freeablo/CMakeLists.txt
@@ -1,33 +1,33 @@
 add_library(freeablo_lib # split into a library so I can link to it from tests
-    fa_main.cpp 
+    fa_main.cpp
 
-    falevelgen/levelgen.h 
-    falevelgen/levelgen.cpp 
-    falevelgen/random.cpp 
-    falevelgen/random.h 
-    falevelgen/mst.cpp 
+    falevelgen/levelgen.h
+    falevelgen/levelgen.cpp
+    falevelgen/random.cpp
+    falevelgen/random.h
+    falevelgen/mst.cpp
     falevelgen/mst.h
     falevelgen/tileset.cpp
     falevelgen/tileset.h
-    
+
     farender/renderer.cpp
     farender/renderer.h
     farender/spritecache.cpp
     farender/spritecache.h
     farender/spritemanager.cpp
     farender/spritemanager.h
-    
+
     faworld/actor.cpp
-    faworld/actor.h 
+    faworld/actor.h
     faworld/monster.h
-    faworld/monster.cpp 
-    faworld/player.h  
+    faworld/monster.cpp
+    faworld/player.h
     faworld/player.cpp
     faworld/playerfactory.h
     faworld/playerfactory.cpp
-    faworld/position.h  
+    faworld/position.h
     faworld/position.cpp
-    faworld/world.cpp  
+    faworld/world.cpp
     faworld/world.h
     faworld/inventory.h
     faworld/inventory.cpp
@@ -45,7 +45,9 @@ add_library(freeablo_lib # split into a library so I can link to it from tests
     faworld/gamelevel.h
     faworld/findpath.h
     faworld/findpath.cpp
-    
+    faworld/hoverstate.h
+    faworld/hoverstate.cpp
+
     fagui/guimanager.h
     fagui/guimanager.cpp
     fagui/animateddecorator.h
@@ -70,7 +72,7 @@ add_library(freeablo_lib # split into a library so I can link to it from tests
     engine/inputobserverinterface.h
     engine/enginemain.h
     engine/enginemain.cpp
-    
+
     engine/net/netmanager.cpp
     engine/net/netmanager.h
     engine/net/server.h

--- a/apps/freeablo/engine/engineinputmanager.cpp
+++ b/apps/freeablo/engine/engineinputmanager.cpp
@@ -2,17 +2,18 @@
 #include "../farender/renderer.h"
 #include "../fagui/console.h"
 #include "engineinputmanager.h"
+#include "misc/utility.h"
 
 namespace Engine
 {
     namespace ph = std::placeholders;
 
     EngineInputManager::EngineInputManager():
-        mInput( std::bind(&EngineInputManager::keyPress,this, ph::_1),
+        mInput( BIND_THIS (keyPress),
                 NULL,
-                std::bind(&EngineInputManager::mouseClick, this, ph::_1, ph::_2, ph::_3),
-                std::bind(&EngineInputManager::mouseRelease, this, ph::_1, ph::_2, ph::_3),
-                std::bind(&EngineInputManager::mouseMove, this, ph::_1, ph::_2),
+                BIND_THIS (mouseClick),
+                BIND_THIS (mouseRelease),
+                BIND_THIS (mouseMove),
                 FARender::Renderer::get()->getRocketContext())
     {
         for(int action = 0; action < KEYBOARD_INPUT_ACTION_MAX; action++)
@@ -147,6 +148,7 @@ namespace Engine
     void EngineInputManager::mouseMove(size_t x, size_t y)
     {
         mMousePosition = Point(x,y);
+       notifyMouseObservers(MOUSE_MOVE, mMousePosition);
     }
 
     std::string EngineInputManager::keyboardActionToString(KeyboardInputAction action) const

--- a/apps/freeablo/engine/enginemain.cpp
+++ b/apps/freeablo/engine/enginemain.cpp
@@ -94,6 +94,7 @@ namespace Engine
         int32_t currentLevel = variables["level"].as<int32_t>();
 
         FAGui::GuiManager guiManager(player->mInventory, *this, characterClass);
+        world.setGuiManager (&guiManager); // is this bad for world to know about guimanager at all?
 
         // -1 represents the main menu
         if(currentLevel != -1 && isServer)

--- a/apps/freeablo/engine/inputobserverinterface.h
+++ b/apps/freeablo/engine/inputobserverinterface.h
@@ -17,7 +17,8 @@ namespace Engine {
     {
         MOUSE_RELEASE,
         MOUSE_DOWN,
-        MOUSE_CLICK
+        MOUSE_CLICK,
+        MOUSE_MOVE,
     };
 
     struct Point

--- a/apps/freeablo/fagui/guimanager.cpp
+++ b/apps/freeablo/fagui/guimanager.cpp
@@ -11,11 +11,11 @@
 #include "animateddecoratorinstancer.h"
 #include "../engine/threadmanager.h"
 #include "scrollbox.h"
-
+#include "misc/stringops.h"
 
 
 namespace FAGui
-{   
+{
     std::map<std::string, Rocket::Core::ElementDocument*> menus;
 
     std::string GuiManager::invClass;
@@ -43,6 +43,7 @@ namespace FAGui
         menus["invalidNameMenu"] = renderer->getRocketContext()->LoadDocument("resources/gui/creator/invalid_name_menu.rml");
         menus["selectHeroMenu"] = renderer->getRocketContext()->LoadDocument("resources/gui/creator/select_hero_menu.rml");
         menus["saveFileExistsMenu"] = renderer->getRocketContext()->LoadDocument("resources/gui/creator/save_file_exists_menu.rml");
+        menus["bottomMenu"] = renderer->getRocketContext()->LoadDocument("resources/gui/bottommenu.rml");
     }
 
     void GuiManager::openDialogue(const std::string& document)
@@ -104,6 +105,7 @@ namespace FAGui
         menus["ingameUi"]->PushToBack(); // base.rml is an empty sheet that covers the whole screen for
         // detecting clicks outside the gui, push it to back so it doesn't
         // block clicks on the real gui.
+        menus["bottomMenu"]->Show ();
 
         mCurrentGuiType = IngameMenu;
     }
@@ -295,6 +297,18 @@ namespace FAGui
 
         showFadeElement();
         computeFadeDelta();
+    }
+
+    void GuiManager::setStatusBarText(std::string text) {
+      auto element = menus["bottomMenu"]->GetElementById("statusBarContents");
+      if (!element)
+        return;
+      Misc::StringUtils::toLower (text); // Because uppercase letters are not supported in "White" font
+
+      auto height = static_cast<int> (element->GetParentNode()->GetBox ().GetSize ().y);
+      // yes it was technically possible to implement it in css but rocketlib was displaying solution I came up with incorrectly :(
+      element->SetAttribute("style", ("vertical-align:middle;line-height:" + std::to_string (height / (std::count (text.begin (), text.end (), '\n') + 1)) + "px;").c_str ());
+      element->SetInnerRML(text.c_str ());
     }
 
     void GuiManager::updateFadeIn()

--- a/apps/freeablo/fagui/guimanager.h
+++ b/apps/freeablo/fagui/guimanager.h
@@ -53,6 +53,7 @@ namespace FAGui
         void showInvalidNameMenu(int classNumber);
         void update(bool paused);
         GuiType currentGuiType() const;
+        void setStatusBarText(std::string text);
         static std::string invClass;
 
         FAPythonFuncs mPythonFuncs;

--- a/apps/freeablo/falevelgen/levelgen.cpp
+++ b/apps/freeablo/falevelgen/levelgen.cpp
@@ -928,6 +928,7 @@ namespace FALevelGen
             DiabloExe::Monster monster =  exe.getMonster(name);
 
             FAWorld::Monster * monsterObj = new FAWorld::Monster(monster, FAWorld::Position(xPos, yPos));
+            monsterObj->setName(name);
             actors.push_back(monsterObj);
         }
     }

--- a/apps/freeablo/farender/renderer.cpp
+++ b/apps/freeablo/farender/renderer.cpp
@@ -182,7 +182,7 @@ namespace FARender
         return mSpriteManager.getPathForIndex(index);
     }
 
-    Render::Tile Renderer::getClickedTile(size_t x, size_t y, const FAWorld::Position& screenPos)
+    Render::Tile Renderer::getTileByScreenPos(size_t x, size_t y, const FAWorld::Position& screenPos)
     {
         return Render::getClickedTile(x, y, screenPos.current().first, screenPos.current().second, screenPos.next().first, screenPos.next().second, screenPos.mDist);
     }

--- a/apps/freeablo/farender/renderer.cpp
+++ b/apps/freeablo/farender/renderer.cpp
@@ -229,21 +229,24 @@ namespace FARender
 
                 for(size_t i = 0; i < state->mObjects.size(); i++)
                 {
-                    FAWorld::Position & position = std::get<2>(state->mObjects[i]);
+                    auto &object = state->mObjects[i];
+                    FAWorld::Position & position = object.position;
 
                     size_t x = position.current().first;
                     size_t y = position.current().second;
 
-                    mLevelObjects[x][y].valid = std::get<0>(state->mObjects[i])->isValid();
-                    mLevelObjects[x][y].spriteCacheIndex = std::get<0>(state->mObjects[i])->getCacheIndex();
-                    mLevelObjects[x][y].spriteFrame = std::get<1>(state->mObjects[i]);
+                    mLevelObjects[x][y].valid = object.spriteGroup->isValid();
+                    mLevelObjects[x][y].spriteCacheIndex = object.spriteGroup->getCacheIndex();
+                    mLevelObjects[x][y].spriteFrame = object.frame;
                     mLevelObjects[x][y].x2 = position.next().first;
                     mLevelObjects[x][y].y2 = position.next().second;
                     mLevelObjects[x][y].dist = position.mDist;
+                    mLevelObjects[x][y].hoverColor = object.hoverColor;
                 }
 
-                Render::drawLevel(state->level->mLevel, state->tileset.minTops->getCacheIndex(), state->tileset.minBottoms->getCacheIndex(), &mSpriteManager, mLevelObjects, state->mPos.current().first, state->mPos.current().second,
-                    state->mPos.next().first, state->mPos.next().second, state->mPos.mDist);
+                Render::drawLevel(state->level->mLevel, state->tileset.minTops->getCacheIndex(), state->tileset.minBottoms->getCacheIndex(),
+                                  &mSpriteManager, mLevelObjects, state->mPos.current().first, state->mPos.current().second,
+                                  state->mPos.next().first, state->mPos.next().second, state->mPos.mDist);
             }
 
             Render::drawGui(state->guiDrawBuffer, &mSpriteManager);

--- a/apps/freeablo/farender/renderer.h
+++ b/apps/freeablo/farender/renderer.h
@@ -81,7 +81,7 @@ namespace FARender
             void fillServerSprite(uint32_t index, const std::string& path);
             std::string getPathForIndex(uint32_t index);
 
-            Render::Tile getClickedTile(size_t x, size_t y, const FAWorld::Position& screenPos);
+            Render::Tile getTileByScreenPos(size_t x, size_t y, const FAWorld::Position& screenPos);
 
             Rocket::Core::Context* getRocketContext();
 

--- a/apps/freeablo/farender/renderer.h
+++ b/apps/freeablo/farender/renderer.h
@@ -36,7 +36,7 @@ namespace FARender
 
     struct ObjectToRender {
       FASpriteGroup* spriteGroup;
-      uint32_t frame;
+      size_t frame;
       FAWorld::Position position;
       boost::optional<Cel::Colour> hoverColor;
     };

--- a/apps/freeablo/farender/renderer.h
+++ b/apps/freeablo/farender/renderer.h
@@ -34,6 +34,13 @@ namespace FARender
             friend class Renderer;
     };
 
+    struct ObjectToRender {
+      FASpriteGroup* spriteGroup;
+      uint32_t frame;
+      FAWorld::Position position;
+      boost::optional<Cel::Colour> hoverColor;
+    };
+
     class RenderState
     {
         public:
@@ -42,7 +49,7 @@ namespace FARender
 
         FAWorld::Position mPos;
 
-        std::vector<std::tuple<FASpriteGroup*, uint32_t, FAWorld::Position> > mObjects; ///< group, index into group, and position
+        std::vector<ObjectToRender> mObjects; ///< group, index into group, and position
 
         std::vector<DrawCommand> guiDrawBuffer;
 

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -340,7 +340,11 @@ namespace FAWorld
         mCanTalk = canTalk;
     }
 
-    bool Actor::canTalk() const
+  void Actor::setName(const std::string& name) {
+      mName = name;
+  }
+
+  bool Actor::canTalk() const
     {
         return mCanTalk;
     }

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -76,14 +76,10 @@ namespace FAWorld
                             auto nextPos = mPos.pathNext(false);
                             FAWorld::Actor* actorAtNext = world.getActorAt(nextPos.first, nextPos.second);
 
-                            if ((noclip || (mLevel->getTile(nextPos.first, nextPos.second).passable() &&
-                                (actorAtNext == NULL || actorAtNext == this))) && !mAnimPlaying)
+                            if (noclip || (mLevel->isPassableFor (nextPos.first, nextPos.second, this)) && !mAnimPlaying)
                             {
-                                if (!mPos.mMoving && !mAnimPlaying)
-                                {
-                                    mPos.mMoving = true;
-                                    setAnimation(AnimState::walk);
-                                }
+                                mPos.mMoving = true;
+                                setAnimation(AnimState::walk);
                             }
                             else if (!mAnimPlaying)
                             {

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -28,7 +28,6 @@ namespace FAWorld
             if (advanceAnims)
             {
                 auto currentAnim = getCurrentAnim();
-
                 if (mAnimPlaying)
                 {
                     if (mFrame < currentAnim->getAnimLength())
@@ -100,9 +99,9 @@ namespace FAWorld
             }
             else if (mPos.mMoving && mPos.mDist == 0 && !mAnimPlaying)
             {
-                checkAttackTalkAction ();
                 mPos.mMoving = false;
                 setAnimation(AnimState::idle);
+                checkAttackTalkAction ();
             }
 
             if (!mIsDead && !mPos.mMoving && !mAnimPlaying && mAnimState != AnimState::idle)

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -74,9 +74,8 @@ namespace FAWorld
                         else
                         {
                             auto nextPos = mPos.pathNext(false);
-                            FAWorld::Actor* actorAtNext = world.getActorAt(nextPos.first, nextPos.second);
 
-                            if (noclip || (mLevel->isPassableFor (nextPos.first, nextPos.second, this)) && !mAnimPlaying)
+                            if ((noclip || mLevel->isPassableFor (nextPos.first, nextPos.second, this)) && !mAnimPlaying)
                             {
                                 mPos.mMoving = true;
                                 setAnimation(AnimState::walk);

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -232,7 +232,7 @@ namespace FAWorld
     bool Actor::findPath(GameLevelImpl * level, std::pair<int32_t, int32_t> destination)
     {
         bool bArrivable = false;
-        mPos.mPath = std::move(FindPath::get(level)->find(mPos.current(), destination, bArrivable, this));
+        mPos.mPath = FindPath::get(level)->find(mPos.current(), destination, bArrivable, this);
         mPos.mGoal = destination; // destination maybe changed by findPath.
         mPos.mIndex = 0;
         return bArrivable;

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -39,7 +39,7 @@ namespace FAWorld
             hit,
             ENUM_END // always leave this as the last entry, and don't set explicit values for any of the entries
         };
-    }    
+    }
     class Actor : public NetObject
     {
         STATIC_HANDLE_NET_OBJECT_IN_CLASS()
@@ -64,7 +64,7 @@ namespace FAWorld
             virtual FARender::FASpriteGroup* getCurrentAnim();
             void setAnimation(AnimState::AnimState state, bool reset=false);
             void setWalkAnimation(const std::string path);
-            void setIdleAnimation(const std::string path);            
+            void setIdleAnimation(const std::string path);
             AnimState::AnimState getAnimState();
             bool findPath(GameLevelImpl* level, std::pair<int32_t, int32_t> destination);
 
@@ -72,6 +72,11 @@ namespace FAWorld
             int32_t getId()
             {
                 return mId;
+            }
+
+            std::string getName()
+            {
+                return mName;
             }
 
             virtual void setLevel(GameLevel* level);
@@ -89,14 +94,14 @@ namespace FAWorld
                 return false;
             }
 
-            Position mPos;            
+            Position mPos;
         //private: //TODO: fix this
             FARender::FASpriteGroup* mWalkAnim = FARender::getDefaultSprite();
             FARender::FASpriteGroup* mIdleAnim = FARender::getDefaultSprite();
             FARender::FASpriteGroup* mDieAnim = FARender::getDefaultSprite();
             FARender::FASpriteGroup* mAttackAnim = FARender::getDefaultSprite();
             FARender::FASpriteGroup* mHitAnim = FARender::getDefaultSprite();
-        
+
             size_t mFrame;
             virtual void die();
             std::pair<int32_t, int32_t> mDestination;
@@ -111,6 +116,7 @@ namespace FAWorld
             std::string getActorId() const;
             void setActorId(const std::string& id);
             void setCanTalk(bool canTalk);
+            void setName (const std::string &name);
 
             std::map<AnimState::AnimState, size_t> mAnimTimeMap;
             ActorStats * mStats=nullptr;
@@ -243,6 +249,7 @@ namespace FAWorld
 
         private:
             std::string mActorId;
+            std::string mName;
             int32_t mId;
             friend class Engine::Server; // TODO: fix
             friend class Engine::Client;

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -51,6 +51,7 @@ namespace FAWorld
                   const std::string& dieAnimPath=""
                   );
 
+            bool checkAttackTalkAction();
             void update(bool noclip, size_t ticksPassed);
             virtual ~Actor();
             virtual std::string getDieWav(){return "";}

--- a/apps/freeablo/faworld/findpath.cpp
+++ b/apps/freeablo/faworld/findpath.cpp
@@ -32,7 +32,7 @@ namespace FAWorld
 
     bool FindPath::passable(Location location)
     {
-        bool isPassable = level->isPassable(location.first, location.second);
+        bool isPassable = level->isPassableFor(location.first, location.second, mActor);
         return isPassable;
     }
 
@@ -147,8 +147,9 @@ namespace FAWorld
         return result;
     }
 
-    vector<FindPath::Location> FindPath::find(FindPath::Location start, FindPath::Location& goal, bool& bArrivable)
+    vector<FindPath::Location> FindPath::find(FindPath::Location start, FindPath::Location& goal, bool& bArrivable, const Actor *actor)
     {
+        mActor = actor;
         unordered_map<Location, int> costSoFar;
         unordered_map<Location, Location> cameFrom;
 

--- a/apps/freeablo/faworld/findpath.cpp
+++ b/apps/freeablo/faworld/findpath.cpp
@@ -66,10 +66,10 @@ namespace FAWorld
     }
 
     bool FindPath::AStarSearch(
-        FindPath::Location start,
-        FindPath::Location goal,
-        unordered_map<FindPath::Location, FindPath::Location>& came_from,
-        unordered_map<FindPath::Location, int>& costSoFar)
+      FindPath::Location start,
+      FindPath::Location& goal,
+      unordered_map<FindPath::Location, FindPath::Location>& came_from,
+      unordered_map<FindPath::Location, int>& costSoFar)
     {
         PriorityQueue<Location> frontier;
         frontier.put(start, 0);
@@ -80,10 +80,19 @@ namespace FAWorld
             Location current = frontier.get();
 
             // Early exit
-            if (current == goal)
-            {
-                return true;
-            }
+            if (passable (goal))
+              {
+                if (current == goal)
+                  return true;
+              }
+            else // if we didn't reach goal and it's unreachable but we reach neighbour's tile, then it's our new goal
+              {
+                if (abs (goal.first - current.first) <= 1 && abs (goal.second - current.second) <= 1)
+                    {
+                      goal = current;
+                      return true;
+                    }
+              }
 
             vector<Location> neighborsContainer = neighbors(current);
             for (vector<Location>::iterator it = neighborsContainer.begin(); it != neighborsContainer.end(); it++)
@@ -153,8 +162,12 @@ namespace FAWorld
         unordered_map<Location, int> costSoFar;
         unordered_map<Location, Location> cameFrom;
 
+        // looks like original game does the following: it reaches one of neighbor tiles (possibly one with sqrt (2) distance, not 1 if it's closer)
+        // of the target if target itself is not passable, otherwise it does nothing. Also resolution of its search is much lower.
+        // the reaching neighbor tile fastest way is important since it allows to talk with/perform melee attack on target
+
         bool found = AStarSearch(start, goal, cameFrom, costSoFar);
-        if (!found) {
+        if (!found) { // so according to above explanation part in this branch is not performed by original game, I'll leave it be for now
             goal = findClosesPointToGoal(start, goal, cameFrom);
             bArrivable = false;
         }

--- a/apps/freeablo/faworld/findpath.h
+++ b/apps/freeablo/faworld/findpath.h
@@ -72,7 +72,7 @@ namespace FAWorld
         bool passable(Location location);
         vector<Location> neighbors(Location location);
         int heuristic(Location a, Location b);
-        bool AStarSearch(Location start, Location goal, unordered_map<Location, Location>& cameFrom, unordered_map<Location, int>& costSoFar);
+        bool AStarSearch(Location start, FindPath::Location& goal, unordered_map<Location, Location>& cameFrom, unordered_map<Location, int>& costSoFar);
         vector<Location> reconstructPath(Location start, Location goal, unordered_map<Location, Location>& cameFrom);
         Location findClosesPointToGoal(Location start, Location goal, unordered_map<Location, Location> & cameFrom);
 

--- a/apps/freeablo/faworld/findpath.h
+++ b/apps/freeablo/faworld/findpath.h
@@ -62,7 +62,7 @@ namespace FAWorld
         typedef pair<int32_t, int32_t> Location;
 
         FindPath(GameLevelImpl * level);
-        vector<Location> find(Location start, Location& goal,bool& bArrivable);
+        vector<Location> find(Location start, Location& goal,bool& bArrivable, const Actor *actor = nullptr);
         static FindPath* get(GameLevelImpl* level);
 
     private:
@@ -80,6 +80,7 @@ namespace FAWorld
         vector<Location> directions;
         unsigned int sizeOfDirections;
         static FindPath* instance;
+        const Actor *mActor;
     };
 
 }

--- a/apps/freeablo/faworld/gamelevel.cpp
+++ b/apps/freeablo/faworld/gamelevel.cpp
@@ -114,9 +114,19 @@ namespace FAWorld
         return mLevel[x][y].passable();
     }
 
-    Actor* GameLevel::getActorAt(size_t x, size_t y)
+    bool GameLevel::isPassableFor(int x, int y, const Actor *actor) const
     {
-        return mActorMap2D[std::pair<size_t, size_t>(x, y)];
+      auto actorAtPos = getActorAt (x, y);
+      return mLevel[x][y].passable() && (actorAtPos == nullptr || actorAtPos == actor);
+    }
+
+    Actor* GameLevel::getActorAt(size_t x, size_t y) const
+    {
+      auto it = mActorMap2D.find (std::pair<size_t, size_t>(x, y));
+      if (it != mActorMap2D.end ())
+        return it->second;
+
+      return nullptr;
     }
 
     void GameLevel::addActor(Actor* actor)

--- a/apps/freeablo/faworld/gamelevel.cpp
+++ b/apps/freeablo/faworld/gamelevel.cpp
@@ -117,7 +117,7 @@ namespace FAWorld
     bool GameLevel::isPassableFor(int x, int y, const Actor *actor) const
     {
       auto actorAtPos = getActorAt (x, y);
-      return mLevel[x][y].passable() && (actorAtPos == nullptr || actorAtPos == actor);
+      return mLevel[x][y].passable() && (actorAtPos == nullptr || actorAtPos == actor || actorAtPos->isDead());
     }
 
     Actor* GameLevel::getActorAt(size_t x, size_t y) const

--- a/apps/freeablo/faworld/gamelevel.cpp
+++ b/apps/freeablo/faworld/gamelevel.cpp
@@ -125,6 +125,9 @@ namespace FAWorld
         actorMapInsert(actor);
     }
 
+    static const Cel::Colour friendHoverColor = {180, 110, 110, true};
+    static const Cel::Colour enemyHoverColor = {164, 46, 46, true};
+
     void GameLevel::fillRenderState(FARender::RenderState* state)
     {
         state->mObjects.clear();
@@ -132,7 +135,10 @@ namespace FAWorld
         for(size_t i = 0; i < mActors.size(); i++)
         {
             size_t frame = mActors[i]->mFrame + mActors[i]->mPos.mDirection * mActors[i]->getCurrentAnim()->getAnimLength();
-            state->mObjects.push_back(std::tuple<FARender::FASpriteGroup*, size_t, FAWorld::Position>(mActors[i]->getCurrentAnim(), frame, mActors[i]->mPos));
+            boost::optional<Cel::Colour> hoverColor;
+            if (mHoverState.isActorHovered(mActors[i]->getId()))
+              hoverColor = mActors[i]->isEnemy () ? enemyHoverColor : friendHoverColor;
+            state->mObjects.push_back({mActors[i]->getCurrentAnim(), frame, mActors[i]->mPos, hoverColor});
         }
     }
 
@@ -170,7 +176,11 @@ namespace FAWorld
         return dataSavingTmp;
     }
 
-    GameLevel* GameLevel::loadFromString(const std::string& data)
+  HoverState& GameLevel::getHoverState() {
+      return mHoverState;
+  }
+
+  GameLevel* GameLevel::loadFromString(const std::string& data)
     {
         GameLevel* retval = new GameLevel();
 
@@ -198,4 +208,7 @@ namespace FAWorld
     {
         actors.insert(actors.end(), mActors.begin(), mActors.end());
     }
+
+  GameLevel::GameLevel() {
+  }
 }

--- a/apps/freeablo/faworld/gamelevel.h
+++ b/apps/freeablo/faworld/gamelevel.h
@@ -25,6 +25,7 @@ namespace FAWorld
         virtual size_t width() const = 0;
         virtual size_t height() const = 0;
         virtual bool isPassable(int x, int y) const = 0;
+        virtual bool isPassableFor(int x, int y, const Actor* actor) const = 0;
     };
 
     class GameLevel :public GameLevelImpl
@@ -52,9 +53,10 @@ namespace FAWorld
         void actorMapRemove(Actor* actor);
         void actorMapClear();
         void actorMapRefresh();
-        virtual bool isPassable(int x, int y) const;
+        bool isPassable(int x, int y) const override;
+        bool isPassableFor(int x, int y, const Actor* actor) const override;
 
-        Actor* getActorAt(size_t x, size_t y);
+      Actor* getActorAt(size_t x, size_t y) const;
 
         void addActor(Actor* actor);
 

--- a/apps/freeablo/faworld/gamelevel.h
+++ b/apps/freeablo/faworld/gamelevel.h
@@ -5,6 +5,8 @@
 
 #include <enet/enet.h> // TODO: remove
 
+#include "hoverstate.h"
+
 namespace FARender
 {
     class Renderer;
@@ -66,6 +68,7 @@ namespace FAWorld
         }
 
         std::string serialiseToString();
+        HoverState& getHoverState();
         static GameLevel* loadFromString(const std::string& data);
 
         Actor* getActorById(int32_t id);
@@ -73,10 +76,11 @@ namespace FAWorld
         void getActors(std::vector<Actor*>& actors);
 
     private:
-        GameLevel() {}
+      GameLevel();
 
         Level::Level mLevel;
         size_t mLevelIndex;
+        HoverState mHoverState;
 
         std::vector<Actor*> mActors;
         std::map<std::pair<size_t, size_t>, Actor*> mActorMap2D;    ///< Map of points to actors.

--- a/apps/freeablo/faworld/hoverstate.cpp
+++ b/apps/freeablo/faworld/hoverstate.cpp
@@ -1,0 +1,35 @@
+#include "hoverstate.h"
+
+bool HoverState::applyIfNeeded(const HoverState& newState) {
+    if (*this == newState)
+      return false;
+
+    *this = newState;
+    return true;
+  }
+
+  bool HoverState::operator==(const HoverState& other) const {
+    if (mType != other.mType)
+      return false;
+
+    switch (mType) {
+    case HoverType::actor:
+      return mActorId == other.mActorId;
+    }
+    return true;
+  }
+
+  bool HoverState::setActorHovered(int32_t actorIdArg) {
+    HoverState newState (HoverType::actor);
+    newState.mActorId = actorIdArg;
+    return applyIfNeeded (newState);
+  }
+
+  bool HoverState::setNothingHovered() {
+    HoverState newState (HoverType::none);
+    return applyIfNeeded (newState);
+  }
+
+bool HoverState::isActorHovered(int32_t actorId) const {
+  return mType == HoverType::actor && actorId == mActorId;
+}

--- a/apps/freeablo/faworld/hoverstate.cpp
+++ b/apps/freeablo/faworld/hoverstate.cpp
@@ -15,6 +15,7 @@ bool HoverState::applyIfNeeded(const HoverState& newState) {
     switch (mType) {
     case HoverType::actor:
       return mActorId == other.mActorId;
+    case HoverType::none: break;
     }
     return true;
   }

--- a/apps/freeablo/faworld/hoverstate.h
+++ b/apps/freeablo/faworld/hoverstate.h
@@ -1,0 +1,31 @@
+#ifndef HOVER_STATE_H
+#define HOVER_STATE_H
+
+#include <cstdint>
+
+enum class HoverType
+  {
+    actor,
+    none,
+  };
+
+class HoverState // TODO: move to some other place, maybe even guimanager
+    {
+      HoverType mType = HoverType::none;
+      int32_t mActorId = 0;
+
+    public:
+      HoverState () {}
+      bool applyIfNeeded(const HoverState& newState);
+      bool operator==(const HoverState& other) const;
+      // for now this function if state was applied and if it was caller should ask guimanager to update status bar
+      // later on logic probably will be different.
+      bool setActorHovered(int32_t actorIdArg);
+      bool setNothingHovered();
+      bool isActorHovered (int32_t actorId) const;
+
+    private:
+      HoverState (HoverType typeArg) : mType (typeArg) {}
+    };
+
+#endif // HOVER_STATE_H

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -47,7 +47,11 @@ namespace FAWorld
         FAWorld::World::get()->deregisterPlayer(this);
     }
 
-    bool Player::attack(Actor *enemy)
+  bool Player::isMoving() {
+      return mPos.mMoving;
+  }
+
+  bool Player::attack(Actor *enemy)
     {
         if(enemy->isDead() && enemy->mStats != nullptr)
             return false;

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -13,6 +13,7 @@ namespace FAWorld
             Player();
             Player(const std::string& className, const DiabloExe::CharacterStats& charStats);
             virtual ~Player();
+            bool isMoving();
             Inventory mInventory;
             void setSpriteClass(std::string className);
             bool attack(Actor * enemy);

--- a/apps/freeablo/faworld/position.cpp
+++ b/apps/freeablo/faworld/position.cpp
@@ -38,13 +38,13 @@ namespace FAWorld
         return mCurrent;
     }
 
-    double Position::distanceFrom(Position B)
+    double Position::distanceFrom(const Position &B)
     {
         int dx = mCurrent.first - B.mCurrent.first;
         int dy = mCurrent.second - B.mCurrent.second;
 
-        double x = pow(dx, 2.0);
-        double y = pow(dy, 2.0);
+        double x = dx * dx;
+        double y = dy * dy;
         double distance = sqrt(x + y);
 
         return distance;

--- a/apps/freeablo/faworld/position.h
+++ b/apps/freeablo/faworld/position.h
@@ -31,8 +31,8 @@ namespace FAWorld
             std::pair<int32_t, int32_t> mGoal;  ///< the movement goal point. it maybe changed by findPath,otherwise it maybe 0 if findpath failed. It's necessary and different from World::mDestination.
             int mIndex;///< index
             bool mMoving;
-            double distanceFrom(Position B);
-        
+            double distanceFrom(const Position &B);
+
         private:
             std::pair<int32_t, int32_t> mCurrent;
 
@@ -61,7 +61,7 @@ namespace FAWorld
 
             BOOST_SERIALIZATION_SPLIT_MEMBER()
 
-            template<class Stream> 
+            template<class Stream>
             Serial::Error::Error faSerial(Stream& stream)
             {
                 serialise_int(stream, 0, 100, mDist);

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -315,7 +315,10 @@ namespace FAWorld
     {
       auto tile = getTileByScreenPos(mousePosition);
       auto actor = getActorAt(tile.x, tile.y);
-      if (actor != nullptr)
+      if (!actor && tile.x < getCurrentLevel ()->width() && tile.y < getCurrentLevel()->height ())
+        actor = getActorAt(tile.x + 1, tile.y + 1); // It seems like all actors are 2 "tile" tall for hover and targeting
+
+      if (actor)
           {
             if (m_hoverState.actorHovered (actor->getId ()))
               mGuiManager->setStatusBarText(actor->getName ());

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -289,7 +289,7 @@ namespace FAWorld
       return FARender::Renderer::get()->getTileByScreenPos(screenPos.x, screenPos.y, getCurrentPlayer()->mPos);
     }
 
-    HoverState &World::getHoverState () { return getCurrentLevel ()->getHoverState (); };
+    HoverState &World::getHoverState () { return getCurrentLevel ()->getHoverState (); }
 
     Actor *World::targetedActor(Engine::Point screenPosition)
     {

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -299,7 +299,7 @@ namespace FAWorld
           return nullptr;
 
         auto actor = getActorAt (x, y);
-        if (actor && actor != getCurrentPlayer()) return actor;
+        if (actor && !actor->isDead() && actor != getCurrentPlayer()) return actor;
 
         return nullptr;
       };

--- a/apps/freeablo/faworld/world.h
+++ b/apps/freeablo/faworld/world.h
@@ -77,6 +77,7 @@ namespace FAWorld
             void onMouseClick(Engine::Point mousePosition);
             Render::Tile getTileByScreenPos(Engine::Point screenPos);
             HoverState& getHoverState();
+            Actor* targetedActor(Engine::Point screenPosition);
             void onMouseMove(Engine::Point mousePosition);
             void onMouseDown(Engine::Point mousePosition);
 

--- a/apps/freeablo/faworld/world.h
+++ b/apps/freeablo/faworld/world.h
@@ -7,9 +7,9 @@
 
 #include "../engine/inputobserverinterface.h"
 
-#include <boost/optional/optional.hpp> // TODO: replace with std::optional when available
-#include <boost/signals2/signal.hpp>
 #include "../fagui/guimanager.h"
+
+class HoverState;
 
 namespace Render
 {
@@ -31,30 +31,6 @@ namespace FAWorld
     class Actor;
     class Player;
     class GameLevel;
-
-    enum class HoverType
-    {
-      actor,
-      none,
-    };
-
-    struct HoverState // TODO: move to some other place, maybe even guimanager
-    {
-      HoverType type = HoverType::none;
-      int32_t actorId;
-
-    public:
-      HoverState () {}
-      bool applyIfNeeded(const HoverState& newState);
-      bool operator==(const HoverState& other) const;
-      // for now this function if state was applied and if it was caller should ask guimanager to update status bar
-      // later on logic probably will be different.
-      bool actorHovered(int32_t actorIdArg);
-      bool nothingHovered();
-
-    private:
-      HoverState (HoverType typeArg) : type (typeArg) {}
-    };
 
     class World : public Engine::KeyboardInputObserverInterface, public Engine::MouseInputObserverInterface
     {
@@ -100,11 +76,11 @@ namespace FAWorld
             void stopPlayerActions();
             void onMouseClick(Engine::Point mousePosition);
             Render::Tile getTileByScreenPos(Engine::Point screenPos);
+            HoverState& getHoverState();
             void onMouseMove(Engine::Point mousePosition);
             void onMouseDown(Engine::Point mousePosition);
 
             std::map<size_t, GameLevel*> mLevels;
-            HoverState m_hoverState;
             size_t mTicksPassed = 0;
             Player* mCurrentPlayer;
             std::vector<Player*> mPlayers;

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(Levels
 target_link_libraries(Levels FAIO DiabloExe)
 set_target_properties(Levels PROPERTIES COMPILE_FLAGS "${FA_COMPILER_FLAGS}")
 
-add_library(Misc 
+add_library(Misc
     misc/stringops.h
     misc/helper2d.h
     misc/md5.h
@@ -36,6 +36,7 @@ add_library(Misc
     misc/enablewarn.h
     misc/savePNG.h
     misc/savePNG.cpp
+    misc/utility.h
 )
 target_link_libraries(Misc ${PNG_LIBRARY})
 SET_TARGET_PROPERTIES(Misc PROPERTIES LINKER_LANGUAGE CXX)

--- a/components/misc/utility.h
+++ b/components/misc/utility.h
@@ -1,0 +1,27 @@
+#ifndef UTILITY_H
+#define UTILITY_H
+// for general, uncategorized utility functions which may later be located to appropriate files
+
+namespace detail
+{
+  template<typename T, typename FUNC_T>
+  class func_binder_t
+  {
+    T m_pointer;
+    FUNC_T m_func;
+  public:
+    func_binder_t (T ptr, FUNC_T func): m_pointer (ptr), m_func (func) {}
+
+    template<typename... Args>
+    auto operator() (Args &&... vals) const -> decltype ((m_pointer->*m_func) (std::forward<Args> (vals)...))
+    { return (m_pointer->*m_func) (std::forward<Args> (vals)...); }
+  };
+}
+
+// function to create function object from pointer and member function without specifying anything about arguments
+template<typename T, typename FUNC_T>
+detail::func_binder_t<T, FUNC_T> bind_this (T ptr, FUNC_T func) { return {ptr, func}; }
+// macro to quickly apply it to actual this and while mentioning only member function name (will not work for overloaded function)
+#define BIND_THIS(FUNC_NAME) bind_this(this, &std::remove_pointer<decltype (this)>::type::FUNC_NAME)
+
+#endif // UTILITY_H

--- a/components/render/levelobjects.cpp
+++ b/components/render/levelobjects.cpp
@@ -18,7 +18,7 @@ namespace Render
     {
         return Misc::Helper2D<LevelObjects, LevelObject&>(*this, x, get);
     }
-    
+
     size_t LevelObjects::width()
     {
         return mWidth;

--- a/components/render/levelobjects.h
+++ b/components/render/levelobjects.h
@@ -1,9 +1,9 @@
+#ifndef LEVEL_OBJ_H
+#define LEVEL_OBJ_H
+
 #include "render.h"
 
 #include <misc/helper2d.h>
-
-#ifndef LEVEL_OBJ_H
-#define LEVEL_OBJ_H
 
 namespace Render
 {
@@ -17,6 +17,7 @@ namespace Render
         int32_t x2;
         int32_t y2;
         int32_t dist;
+        boost::optional<Cel::Colour> hoverColor;
     };
 
     class LevelObjects
@@ -28,7 +29,7 @@ namespace Render
 
             size_t width();
             size_t height();
-        
+
         private:
             std::vector<LevelObject> mData;
             size_t mWidth;

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -50,7 +50,9 @@ namespace Render
     {
       int32_t x;
       int32_t y;
-      TileHalf half; // assuming that we never need to get more precise than left/right halfs for now
+      TileHalf half = TileHalf::left; // assuming that we never need to get more precise than left/right halfs for now
+      Tile (int32_t xArg, int32_t yArg) : x (xArg), y (yArg) {}
+      Tile (int32_t xArg, int32_t yArg, TileHalf halfArg) : x (xArg), y (yArg), half (halfArg) {}
     };
     /**
      * @brief Render settings for initialization.

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -40,11 +40,17 @@ namespace Level
 
 namespace Render
 {
+    enum class TileHalf {
+      left,
+      right,
+    };
+
     // Tile mesasured in indexes on tile grid
     struct Tile
     {
       int32_t x;
       int32_t y;
+      TileHalf half; // assuming that we never need to get more precise than left/right halfs for now
     };
     /**
      * @brief Render settings for initialization.

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -20,6 +20,10 @@
 #include "rocketglue/drawcommand.h"
 
 #include <SDL.h>
+
+class LevelObjects;
+class SpriteGroup;
+
 namespace Render
 {
     typedef void* Sprite;
@@ -85,7 +89,7 @@ namespace Render
 
     void draw();
 
-    void drawSprite(const Sprite& sprite, size_t x, size_t y);
+    void drawSprite(const Sprite& sprite, size_t x, size_t y, boost::optional<Cel::Colour> color = boost::none);
 
     class SpriteGroup
     {
@@ -113,10 +117,11 @@ namespace Render
             }
 
             static void toPng(const std::string& celPath, const std::string& pngPath);
-
+            const std::vector<Sprite> &masks () { return mMasks; }
 
         private:
             std::vector<Sprite> mSprites;
+            std::vector<Sprite> mMasks; // used for highlighting during hovering
             size_t mAnimLength;
     };
 

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -287,7 +287,7 @@ namespace Render
     void setpixel(SDL_Surface *s, int x, int y, Cel::Colour c);
     SDL_Surface* createTransparentSurface(size_t width, size_t height);
     void drawFrame(SDL_Surface* s, int start_x, int start_y, const Cel::CelFrame& frame);
-    void drawFrameMask(SDL_Surface* s, int start_x, int start_y, const Cel::CelFrame& frame);
+    void drawFrameMask(SDL_Surface* s, const Cel::CelFrame& frame);
 
     SDL_Surface* loadNonCelImageTrans(const std::string& path, const std::string& extension, bool hasTrans, size_t transR, size_t transG, size_t transB)
     {
@@ -578,7 +578,7 @@ namespace Render
             SDL_FreeSurface(s);
 
             s = createTransparentSurface(cel[i].mWidth, cel[i].mHeight);
-            drawFrameMask(s, 0, 0, cel[i]);
+            drawFrameMask(s, cel[i]);
             mMasks.push_back (SDL_CreateTextureFromSurface (renderer, s));
             SDL_FreeSurface(s);
         }
@@ -776,14 +776,14 @@ namespace Render
         }
     }
 
-    void drawFrameMask (SDL_Surface* s, int start_x, int start_y, const Cel::CelFrame& frame)
+    void drawFrameMask (SDL_Surface* s, const Cel::CelFrame& frame)
     {
-        for(size_t x = 0; x < frame.mWidth; x++)
+        for(int x = 0; x < static_cast<int> (frame.mWidth); x++)
         {
-            for(size_t y = 0; y < frame.mHeight; y++)
+            for(int y = 0; y < static_cast<int> (frame.mHeight); y++)
             {
               constexpr int dirs[4][2] = {{1, 0},{-1, 0},{0, 1},{0, -1}};
-              auto isValid = [&](size_t xArg, size_t yArg){ return xArg >= 0 && yArg >= 0 && xArg < frame.mWidth && yArg < frame.mHeight; };
+              auto isValid = [&](int xArg, int yArg){ return xArg >= 0 && yArg >= 0 && xArg < static_cast<int> (frame.mWidth) && yArg < static_cast<int> (frame.mHeight); };
               auto isBlack = [&]{ return frame[x][y].r == 0 && frame[x][y].g == 0 && frame[x][y].b == 0; };
                 if(frame[x][y].visible && !isBlack ()) {
                     for (auto dir : dirs) {

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -861,7 +861,9 @@ namespace Render
     Tile getTileFromScreenCoords(const Misc::Point& screenPos, const Misc::Point& toScreen)
     {
         auto point = screenPos - toScreen;
-        return {(2 * point.y + point.x) / tileWidth, (2 * point.y - point.x) / tileWidth}; // divisin by 64 is pretty fast btw
+        auto x = std::div (2 * point.y + point.x, tileWidth); // divisin by 64 is pretty fast btw
+        auto y = std::div (2 * point.y - point.x, tileWidth);
+        return {x.quot, y.quot, x.rem > y.rem ? TileHalf::right : TileHalf::left};
     }
 
     static Misc::Point pointBetween (const Tile &start, const Tile &finish, const size_t &percent) {

--- a/resources/gui/base.rml
+++ b/resources/gui/base.rml
@@ -14,12 +14,6 @@ import draggable
 instance = draggable.DraggableWidget(document, -1675, -650)
 def onLoad(document):
     docmanage.init()
-
-    bottomMenuHandle = "resources/gui/bottommenu.rml"
-
-    docmanage.manager.loadDoc(bottomMenuHandle)
-    docmanage.manager.showDoc(bottomMenuHandle)
-
         </script>
     </head>
 

--- a/resources/gui/bottommenu.rml
+++ b/resources/gui/bottommenu.rml
@@ -3,7 +3,7 @@
         <style>
             body
             {
-                font-family: FreeMono;
+                font-family: FreeabloWhite11;
                 text-align: center;
                 bottom: 0px;
                 width: 100%;
@@ -19,6 +19,24 @@
                 background-decorator: image;
                 background-image: /ctrlpan/panel8.cel;
             }
+            #statusBarContainer
+            {
+                left: 185px;
+                top: 66px;
+                width: 275px;
+                height: 60px;
+                position: absolute;
+                text-align: center;
+                z-index: 1;
+                display: inline-block;
+            }
+            /*
+            #statusBarContents
+            {
+                line-height: 60px;
+                vertical-align: middle;
+            }
+            */
             span.beltContainer
             {
                 width: 232px;
@@ -82,6 +100,7 @@ docmanage.manager.loadDoc(docmanage.manager.QuestFile)
         <div class="beltSocket" id="belt6" onclick="instance.onBeltClick(event)" onmouseover="instance.onBeltMouseOver(event)" onmouseout="instance.onBeltMouseOut(event)"></div>
         <div class="beltSocket" id="belt7" onclick="instance.onBeltClick(event)" onmouseover="instance.onBeltMouseOver(event)" onmouseout="instance.onBeltMouseOut(event)"></div>
         </span>
+            <div id="statusBarContainer"><pre id = "statusBarContents" /></div>
             <button id="charBut" onclick="docmanage.manager.toggleDoc(docmanage.manager.CharacterFile)"></button>
             <button id="questBut" onclick="docmanage.manager.toggleDoc(docmanage.manager.QuestFile)"></button>
             <button id="mapBut" onclick="print 'map clicked'"></button>


### PR DESCRIPTION
Some details:
1. Status bar is mostly obvious, just showing actor's name for now. Sadly it required to throw in some hackery i.e. changing rml element attributes in runtime in C++ due to the curious nature of how Diablo aligns text. I came out with html solution but librocket didn't manage to render it correctly sadly.
2. Hover highlighting algorithmically is very easy, we just build texture filled with required color for each 4-connected pixel except exactly black (because black is shadow). However implementation is not obvious, in these commits I build mirror white texture `mask` for each texture to be drawn under the actor with requested color. However later for items I actually made generating highlighted texture with specific color by request (using `&higlight=#XXXXXX`) (Due to the fact that it was needed in librocket code). So there's a bit of logic/code duplication. In general I think the second way is better but it requires some refactoring to implement it for actors. I think later on mask texture may be removed, but for now it works so it's probably ok.
3. How targetting works is found purely by experiment. It seem to follow the same pattern for actors even if actor seems small. Targetting pattern is red hexagon for actor staying on tile a:
<img src="https://cloud.githubusercontent.com/assets/2133957/23825630/40c031ae-069e-11e7-9257-eccd2632f0ea.png" width="200px">

However for some triggerable items possibly future inspection is required.
4. Some fixes for targetting/walking which actually of little matter since I've written mostly new code for all this when writing item pick-up (future commits). The only thing to note is that dead bodies should probably in the future stop being actors since they can a share tile with living actor.
