### PR TITLE
Add support for rendering of multiple actors at the same tile

### DIFF
--- a/apps/freeablo/farender/renderer.cpp
+++ b/apps/freeablo/farender/renderer.cpp
@@ -223,7 +223,7 @@ namespace FARender
                 {
                     for(size_t y = 0; y < mLevelObjects.height(); y++)
                     {
-                        mLevelObjects[x][y].valid = false;
+                        mLevelObjects[x][y].clear();
                     }
                 }
 
@@ -233,13 +233,16 @@ namespace FARender
 
                     size_t x = position.current().first;
                     size_t y = position.current().second;
+                    Render::LevelObject levelObject = {
+                        std::get<0>(state->mObjects[i])->isValid(),
+                        std::get<0>(state->mObjects[i])->getCacheIndex(),
+                        std::get<1>(state->mObjects[i]),
+                        position.next().first,
+                        position.next().second,
+                        position.mDist
+                    };
 
-                    mLevelObjects[x][y].valid = std::get<0>(state->mObjects[i])->isValid();
-                    mLevelObjects[x][y].spriteCacheIndex = std::get<0>(state->mObjects[i])->getCacheIndex();
-                    mLevelObjects[x][y].spriteFrame = std::get<1>(state->mObjects[i]);
-                    mLevelObjects[x][y].x2 = position.next().first;
-                    mLevelObjects[x][y].y2 = position.next().second;
-                    mLevelObjects[x][y].dist = position.mDist;
+                    mLevelObjects[x][y].push_back(levelObject);
                 }
 
                 Render::drawLevel(state->level->mLevel, state->tileset.minTops->getCacheIndex(), state->tileset.minBottoms->getCacheIndex(), &mSpriteManager, mLevelObjects, state->mPos.current().first, state->mPos.current().second,

--- a/apps/freeablo/farender/renderer.cpp
+++ b/apps/freeablo/farender/renderer.cpp
@@ -223,7 +223,9 @@ namespace FARender
                 {
                     for(size_t y = 0; y < mLevelObjects.height(); y++)
                     {
-                        mLevelObjects[x][y].clear();
+                        if (mLevelObjects[x][y].size() > 0) {
+                            mLevelObjects[x][y].clear();
+                        }
                     }
                 }
 

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -92,8 +92,8 @@ namespace FAWorld
                             auto nextPos = mPos.pathNext(false);
                             FAWorld::Actor* actorAtNext = world.getActorAt(nextPos.first, nextPos.second);
 
-                            if ((noclip || (mLevel->getTile(nextPos.first, nextPos.second).passable() &&
-                                (actorAtNext == NULL || actorAtNext == this))) && !mAnimPlaying)
+                            if ((noclip || (mLevel->isPassable(nextPos.first, nextPos.second) &&
+                                (actorAtNext == NULL || actorAtNext == this || actorAtNext->isDead()))) && !mAnimPlaying)
                             {
                                 if (!mPos.mMoving && !mAnimPlaying)
                                 {

--- a/components/render/levelobjects.cpp
+++ b/components/render/levelobjects.cpp
@@ -9,16 +9,16 @@ namespace Render
         mHeight = y;
     }
 
-    LevelObject& get(size_t x, size_t y, LevelObjects& objs)
+    std::vector<LevelObject>& get(size_t x, size_t y, LevelObjects& objs)
     {
         return objs.mData[x+y*objs.mWidth];
     }
 
-    Misc::Helper2D<LevelObjects, LevelObject&> LevelObjects::operator[] (size_t x)
+    Misc::Helper2D<LevelObjects, std::vector<LevelObject>&> LevelObjects::operator[] (size_t x)
     {
-        return Misc::Helper2D<LevelObjects, LevelObject&>(*this, x, get);
+        return Misc::Helper2D<LevelObjects, std::vector<LevelObject>&>(*this, x, get);
     }
-    
+
     size_t LevelObjects::width()
     {
         return mWidth;

--- a/components/render/levelobjects.h
+++ b/components/render/levelobjects.h
@@ -24,17 +24,17 @@ namespace Render
         public:
             void resize(size_t x, size_t y);
 
-            Misc::Helper2D<LevelObjects, LevelObject&> operator[] (size_t x);
+            Misc::Helper2D<LevelObjects, std::vector<LevelObject>&> operator[] (size_t x);
 
             size_t width();
             size_t height();
-        
+
         private:
-            std::vector<LevelObject> mData;
+            std::vector<std::vector<LevelObject>> mData;
             size_t mWidth;
             size_t mHeight;
 
-            friend LevelObject& get(size_t x, size_t y, LevelObjects& obj);
+            friend std::vector<LevelObject>& get(size_t x, size_t y, LevelObjects& obj);
     };
 }
 

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -926,9 +926,11 @@ namespace Render
         if(index < minTops->size())
            drawAtTile ((*minTops)[index], topLeft, tileWidth, staticObjectHeight);
 
-        auto &obj = objs[tile.x][tile.y];
-        if (obj.valid)
-           drawMovingSprite((*cache->get(obj.spriteCacheIndex))[obj.spriteFrame], tile, {obj.x2, obj.y2}, obj.dist, toScreen);
+        auto &objsForTile = objs[tile.x][tile.y];
+        for (auto obj : objsForTile) {
+            if (obj.valid)
+                drawMovingSprite((*cache->get(obj.spriteCacheIndex))[obj.spriteFrame], tile, {obj.x2, obj.y2}, obj.dist, toScreen);
+        }
       });
 
       cache->setImmortal(minTopsHandle, false);


### PR DESCRIPTION
Before the change only one actor per tile was supported in the renderer.  This prohibited some features such as walking over dead enemies (they would flicker out of existence because the player would be drawn instead).

I have changed the data structure from holding a single entity to a vector of entities.  I still haven't figured out how to properly layer them but it seems that in vast majority of cases the player is layered above the dead creature.

The vector is then rendered in order so when we make sure dead enemies are in front and the player comes last it will be properly layered and displayed.

I have also made a change to allow walking over dead enemies.

![Imgur](http://i.imgur.com/MNe5YaO.png)

![Imgur](http://i.imgur.com/kj1teMS.png)