### PR TITLE
Use pushdown state-machine to handle actor state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ link_libraries (
     StormLib
     Audio
     Settings
+    StateMachine
     Script
     Serial
 )

--- a/apps/freeablo/CMakeLists.txt
+++ b/apps/freeablo/CMakeLists.txt
@@ -17,6 +17,11 @@ add_library(freeablo_lib # split into a library so I can link to it from tests
     farender/spritemanager.cpp
     farender/spritemanager.h
 
+    faworld/actor/basestate.cpp
+    faworld/actor/basestate.h
+    faworld/actor/attackstate.cpp
+    faworld/actor/attackstate.h
+
     faworld/actor.cpp
     faworld/actor.h
     faworld/monster.h

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -3,6 +3,7 @@
 #include <misc/misc.h>
 
 #include "actorstats.h"
+#include "actor/basestate.h"
 #include "world.h"
 #include "../engine/threadmanager.h"
 #include "../engine/net/netmanager.h"
@@ -55,78 +56,24 @@ namespace FAWorld
 #endif
             }
 
-            if (mPos.mGoal != std::pair<int32_t, int32_t>(0, 0) && mPos.current() != mPos.mGoal)
-            {
-                Actor * actor;
-                actor = World::get()->getActorAt(mDestination.first, mDestination.second);
-                if (canIAttack(actor))
-                {
-                    std::pair<float, float> vector = Misc::getVec(mPos.current(), mDestination);
-                    mPos.setDirection(Misc::getVecDir(vector));
-                    mPos.update();
-                    mPos.mDist = 0;
+            if (!mActorState.empty()) {
+                if (auto next = mActorState.back()->update(*this, noclip, ticksPassed)) {
+                    mActorState.back()->onExit(*this);
 
-                    attack(actor);
-                }
-                else if (canTalkTo(actor))
-                {
-                    mPos.mDist = 0;
-                    talk(actor);
-                }
-                else if (mPos.mDist == 0)
-                {
-                    World& world = *World::get();
-                    if (!mPos.mPath.size() || mPos.mIndex == -1 || mPos.mPath.back() != mDestination)
-                    {
-                        findPath(world.getCurrentLevel(), mPos.mGoal);
+                    switch (next->op) {
+                        case StateOperation::pop:
+                            mActorState.pop_back();
+                            break;
+                        case StateOperation::push:
+                            mActorState.push_back(next->nextState);
+                        case StateOperation::replace:
+                            mActorState.pop_back();
+                            mActorState.push_back(next->nextState);
+                            break;
                     }
-                    if (!mAnimPlaying)
-                    {
-                        if (mPos.current() == mPos.mGoal)        //the mPos.mGoal maybe changed by the findPath call.so we need judge it again.
-                        {
-                            mPos.mMoving = false;
-                            setAnimation(AnimState::idle);
-                        }
-                        else
-                        {
-                            auto nextPos = mPos.pathNext(false);
-                            FAWorld::Actor* actorAtNext = world.getActorAt(nextPos.first, nextPos.second);
 
-                            if ((noclip || (mLevel->isPassable(nextPos.first, nextPos.second) &&
-                                (actorAtNext == NULL || actorAtNext == this || actorAtNext->isDead()))) && !mAnimPlaying)
-                            {
-                                if (!mPos.mMoving && !mAnimPlaying)
-                                {
-                                    mPos.mMoving = true;
-                                    setAnimation(AnimState::walk);
-                                }
-                            }
-                            else if (!mAnimPlaying)
-                            {
-                                mPos.mMoving = false;
-                                mDestination = mPos.current();
-                                setAnimation(AnimState::idle);
-                            }
-
-                            mPos.setDirection(Misc::getVecDir(Misc::getVec(mPos.current(), nextPos)));
-                        }
-                    }
+                    mActorState.back()->onEnter(*this);
                 }
-            }
-            else if (mPos.mMoving && mPos.mDist == 0 && !mAnimPlaying)
-            {
-                mPos.mMoving = false;
-                setAnimation(AnimState::idle);
-            }
-
-            if (!mIsDead && !mPos.mMoving && !mAnimPlaying && mAnimState != AnimState::idle)
-                setAnimation(AnimState::idle);
-            else if (!mIsDead && mPos.mMoving && !mAnimPlaying && mAnimState != AnimState::walk)
-                setAnimation(AnimState::walk);
-
-            //if walk anim finished,we need move the role to next tiled
-            if (!mAnimPlaying) {
-                mPos.update();
             }
         }
     }
@@ -160,6 +107,8 @@ namespace FAWorld
         mDestination = mPos.current();
         mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1f);
         mAnimTimeMap[AnimState::walk] = FAWorld::World::getTicksInPeriod(0.1f);
+
+        mActorState.push_back(new ActorState::BaseState());
 
         mId = getNewId();
     }

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -56,25 +56,7 @@ namespace FAWorld
 #endif
             }
 
-            if (!mActorState.empty()) {
-                if (auto next = mActorState.back()->update(*this, noclip, ticksPassed)) {
-                    mActorState.back()->onExit(*this);
-
-                    switch (next->op) {
-                        case StateOperation::pop:
-                            mActorState.pop_back();
-                            break;
-                        case StateOperation::push:
-                            mActorState.push_back(next->nextState);
-                        case StateOperation::replace:
-                            mActorState.pop_back();
-                            mActorState.push_back(next->nextState);
-                            break;
-                    }
-
-                    mActorState.back()->onEnter(*this);
-                }
-            }
+            mActorStateMachine->update(noclip, ticksPassed);
         }
     }
 
@@ -108,7 +90,7 @@ namespace FAWorld
         mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1f);
         mAnimTimeMap[AnimState::walk] = FAWorld::World::getTicksInPeriod(0.1f);
 
-        mActorState.push_back(new ActorState::BaseState());
+        mActorStateMachine = new StateMachine::StateMachine<Actor>(new ActorState::BaseState(), this);
 
         mId = getNewId();
     }

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -40,9 +40,17 @@ namespace FAWorld
             ENUM_END // always leave this as the last entry, and don't set explicit values for any of the entries
         };
     }
+
+    namespace ActorState
+    {
+        class BaseState;
+    }
+
     class Actor : public NetObject
     {
         STATIC_HANDLE_NET_OBJECT_IN_CLASS()
+
+        friend class ActorState::BaseState; // TODO: fix
 
         public:
             Actor(const std::string& walkAnimPath="",
@@ -67,6 +75,8 @@ namespace FAWorld
             void setIdleAnimation(const std::string path);
             AnimState::AnimState getAnimState();
             bool findPath(GameLevelImpl* level, std::pair<int32_t, int32_t> destination);
+
+            std::vector<ActorState::BaseState*> mActorState;
 
 
             int32_t getId()
@@ -201,8 +211,6 @@ namespace FAWorld
 
                 return Serial::Error::Success;
             }
-
-
 
         protected:
             GameLevel* mLevel = NULL;

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -5,6 +5,7 @@
 
 #include <boost/format.hpp>
 
+#include <statemachine/statemachine.h>
 #include <misc/misc.h>
 
 #include "../engine/net/netmanager.h"
@@ -15,6 +16,7 @@
 #include "gamelevel.h"
 #include "world.h"
 #include "faction.h"
+
 
 namespace Engine
 {
@@ -76,7 +78,7 @@ namespace FAWorld
             AnimState::AnimState getAnimState();
             bool findPath(GameLevelImpl* level, std::pair<int32_t, int32_t> destination);
 
-            std::vector<ActorState::BaseState*> mActorState;
+            StateMachine::StateMachine<Actor>* mActorStateMachine;
 
 
             int32_t getId()

--- a/apps/freeablo/faworld/actor/attackstate.cpp
+++ b/apps/freeablo/faworld/actor/attackstate.cpp
@@ -7,14 +7,14 @@ namespace FAWorld
     namespace ActorState
     {
 
-        boost::optional<StateChange<BaseState>> AttackState::update(Actor& actor, bool noclip, size_t ticksPassed)
+        boost::optional<StateMachine::StateChange<Actor>> AttackState::update(Actor& actor, bool noclip, size_t ticksPassed)
         {
             UNUSED_PARAM(noclip);
             UNUSED_PARAM(ticksPassed);
 
             if (!actor.mAnimPlaying) {
                 actor.setAnimation(AnimState::idle);
-                return StateChange<BaseState>{StateOperation::pop};
+                return StateMachine::StateChange<Actor>{StateMachine::StateOperation::pop};
             }
 
             return boost::none;

--- a/apps/freeablo/faworld/actor/attackstate.cpp
+++ b/apps/freeablo/faworld/actor/attackstate.cpp
@@ -1,0 +1,32 @@
+#include "attackstate.h"
+#include "../actor.h"
+
+namespace FAWorld
+{
+
+    namespace ActorState
+    {
+
+        boost::optional<StateChange<BaseState>> AttackState::update(Actor& actor, bool noclip, size_t ticksPassed)
+        {
+            UNUSED_PARAM(noclip);
+            UNUSED_PARAM(ticksPassed);
+
+            if (!actor.mAnimPlaying) {
+                actor.setAnimation(AnimState::idle);
+                return StateChange<BaseState>{StateOperation::pop};
+            }
+
+            return boost::none;
+        }
+
+        void AttackState::onEnter(Actor& actor)
+        {
+            actor.isAttacking = true;
+            actor.setAnimation(AnimState::attack, true);
+            actor.mAnimPlaying = true;
+        }
+
+    }
+
+}

--- a/apps/freeablo/faworld/actor/attackstate.h
+++ b/apps/freeablo/faworld/actor/attackstate.h
@@ -1,7 +1,10 @@
 #ifndef ACTOR_ATTACKSTATE_H
 #define ACTOR_ATTACKSTATE_H
 
-#include "basestate.h"
+#include <stddef.h>
+#include <statemachine/statemachine.h>
+#include <misc/misc.h>
+#include <boost/optional.hpp>
 
 namespace FAWorld
 {
@@ -11,11 +14,11 @@ namespace FAWorld
     namespace ActorState
     {
 
-        class AttackState : public BaseState
+        class AttackState : public StateMachine::AbstractState<Actor>
         {
         public:
             ~AttackState() {};
-            boost::optional<StateChange<BaseState>> update(Actor& actor, bool noclip, size_t ticksPassed);
+            boost::optional<StateMachine::StateChange<Actor>> update(Actor& actor, bool noclip, size_t ticksPassed);
 
             void onEnter(Actor& actor);
         };

--- a/apps/freeablo/faworld/actor/attackstate.h
+++ b/apps/freeablo/faworld/actor/attackstate.h
@@ -1,0 +1,27 @@
+#ifndef ACTOR_ATTACKSTATE_H
+#define ACTOR_ATTACKSTATE_H
+
+#include "basestate.h"
+
+namespace FAWorld
+{
+
+    class Actor;
+
+    namespace ActorState
+    {
+
+        class AttackState : public BaseState
+        {
+        public:
+            ~AttackState() {};
+            boost::optional<StateChange<BaseState>> update(Actor& actor, bool noclip, size_t ticksPassed);
+
+            void onEnter(Actor& actor);
+        };
+
+    }
+
+}
+
+#endif

--- a/apps/freeablo/faworld/actor/basestate.cpp
+++ b/apps/freeablo/faworld/actor/basestate.cpp
@@ -9,7 +9,7 @@ namespace FAWorld
     namespace ActorState
     {
 
-        boost::optional<StateChange<BaseState>> BaseState::update(Actor& actor, bool noclip, size_t ticksPassed)
+        boost::optional<StateMachine::StateChange<Actor>> BaseState::update(Actor& actor, bool noclip, size_t ticksPassed)
         {
             UNUSED_PARAM(ticksPassed);
             if (actor.mPos.mGoal != std::pair<int32_t, int32_t>(0, 0) && actor.mPos.current() != actor.mPos.mGoal)
@@ -24,7 +24,7 @@ namespace FAWorld
                     actor.mPos.mDist = 0;
 
                     if (actor.attack(destActor)) {
-                        return StateChange<BaseState>{StateOperation::push, new AttackState()};
+                        return StateMachine::StateChange<Actor>{StateMachine::StateOperation::push, new AttackState()};
                     }
                 }
                 else if (actor.canTalkTo(destActor))

--- a/apps/freeablo/faworld/actor/basestate.cpp
+++ b/apps/freeablo/faworld/actor/basestate.cpp
@@ -1,0 +1,96 @@
+#include "basestate.h"
+
+#include "../actor.h"
+#include "attackstate.h"
+
+namespace FAWorld
+{
+
+    namespace ActorState
+    {
+
+        boost::optional<StateChange<BaseState>> BaseState::update(Actor& actor, bool noclip, size_t ticksPassed)
+        {
+            UNUSED_PARAM(ticksPassed);
+            if (actor.mPos.mGoal != std::pair<int32_t, int32_t>(0, 0) && actor.mPos.current() != actor.mPos.mGoal)
+            {
+                Actor * destActor;
+                destActor = World::get()->getActorAt(actor.mDestination.first, actor.mDestination.second);
+                if (actor.canIAttack(destActor))
+                {
+                    std::pair<float, float> vector = Misc::getVec(actor.mPos.current(), actor.mDestination);
+                    actor.mPos.setDirection(Misc::getVecDir(vector));
+                    actor.mPos.update();
+                    actor.mPos.mDist = 0;
+
+                    if (actor.attack(destActor)) {
+                        return StateChange<BaseState>{StateOperation::push, new AttackState()};
+                    }
+                }
+                else if (actor.canTalkTo(destActor))
+                {
+                    actor.mPos.mDist = 0;
+                    actor.talk(destActor);
+                }
+                else if (actor.mPos.mDist == 0)
+                {
+                    World& world = *World::get();
+                    if (!actor.mPos.mPath.size() || actor.mPos.mIndex == -1 || actor.mPos.mPath.back() != actor.mDestination)
+                    {
+                        actor.findPath(world.getCurrentLevel(), actor.mPos.mGoal);
+                    }
+                    if (!actor.mAnimPlaying)
+                    {
+                        if (actor.mPos.current() == actor.mPos.mGoal)        //the mPos.mGoal maybe changed by the findPath call.so we need judge it again.
+                        {
+                            actor.mPos.mMoving = false;
+                            actor.setAnimation(AnimState::idle);
+                        }
+                        else
+                        {
+                            auto nextPos = actor.mPos.pathNext(false);
+                            FAWorld::Actor* actorAtNext = world.getActorAt(nextPos.first, nextPos.second);
+
+                            if ((noclip || (actor.mLevel->isPassable(nextPos.first, nextPos.second) &&
+                                            (actorAtNext == NULL || actorAtNext == &actor || actorAtNext->isDead()))) && !actor.mAnimPlaying)
+                            {
+                                if (!actor.mPos.mMoving && !actor.mAnimPlaying)
+                                {
+                                    actor.mPos.mMoving = true;
+                                    actor.setAnimation(AnimState::walk);
+                                }
+                            }
+                            else if (!actor.mAnimPlaying)
+                            {
+                                actor.mPos.mMoving = false;
+                                actor.mDestination = actor.mPos.current();
+                                actor.setAnimation(AnimState::idle);
+                            }
+
+                            actor.mPos.setDirection(Misc::getVecDir(Misc::getVec(actor.mPos.current(), nextPos)));
+                        }
+                    }
+                }
+            }
+            else if (actor.mPos.mMoving && actor.mPos.mDist == 0 && !actor.mAnimPlaying)
+            {
+                actor.mPos.mMoving = false;
+                actor.setAnimation(AnimState::idle);
+            }
+
+            if (!actor.mIsDead && !actor.mPos.mMoving && !actor.mAnimPlaying && actor.mAnimState != AnimState::idle)
+                actor.setAnimation(AnimState::idle);
+            else if (!actor.mIsDead && actor.mPos.mMoving && !actor.mAnimPlaying && actor.mAnimState != AnimState::walk)
+                actor.setAnimation(AnimState::walk);
+
+            //if walk anim finished,we need move the role to next tiled
+            if (!actor.mAnimPlaying) {
+                actor.mPos.update();
+            }
+
+            return boost::none;
+        }
+
+    }
+
+}

--- a/apps/freeablo/faworld/actor/basestate.h
+++ b/apps/freeablo/faworld/actor/basestate.h
@@ -1,0 +1,54 @@
+#ifndef ACTOR_BASESTATE_H
+#define ACTOR_BASESTATE_H
+
+#include <stddef.h>
+#include <misc/misc.h>
+#include <boost/optional.hpp>
+
+namespace FAWorld
+{
+
+    class Actor;
+
+    enum StateOperation
+    {
+        pop,
+        push,
+        replace
+    };
+
+    template<typename state> struct StateChange
+    {
+        StateChange(StateOperation op):
+            op(op), nextState(nullptr) {};
+        StateChange(StateOperation op, state* nextState):
+            op(op), nextState(nextState) {};
+        StateOperation op;
+        state* nextState;
+    };
+
+    namespace ActorState
+    {
+
+        class AttackState;
+        class WalkState;
+
+        class BaseState
+        {
+        public:
+            virtual ~BaseState() {};
+            virtual boost::optional<StateChange<BaseState>> update(Actor& actor, bool noclip, size_t ticksPassed);
+            virtual void onEnter(Actor& actor)
+            {
+                UNUSED_PARAM(actor);
+            };
+            virtual void onExit(Actor& actor)
+            {
+                UNUSED_PARAM(actor);
+            };
+        };
+
+    }
+}
+
+#endif

--- a/apps/freeablo/faworld/actor/basestate.h
+++ b/apps/freeablo/faworld/actor/basestate.h
@@ -2,6 +2,7 @@
 #define ACTOR_BASESTATE_H
 
 #include <stddef.h>
+#include <statemachine/statemachine.h>
 #include <misc/misc.h>
 #include <boost/optional.hpp>
 
@@ -10,42 +11,14 @@ namespace FAWorld
 
     class Actor;
 
-    enum StateOperation
-    {
-        pop,
-        push,
-        replace
-    };
-
-    template<typename state> struct StateChange
-    {
-        StateChange(StateOperation op):
-            op(op), nextState(nullptr) {};
-        StateChange(StateOperation op, state* nextState):
-            op(op), nextState(nextState) {};
-        StateOperation op;
-        state* nextState;
-    };
-
     namespace ActorState
     {
 
-        class AttackState;
-        class WalkState;
-
-        class BaseState
+        class BaseState: public StateMachine::AbstractState<Actor>
         {
         public:
-            virtual ~BaseState() {};
-            virtual boost::optional<StateChange<BaseState>> update(Actor& actor, bool noclip, size_t ticksPassed);
-            virtual void onEnter(Actor& actor)
-            {
-                UNUSED_PARAM(actor);
-            };
-            virtual void onExit(Actor& actor)
-            {
-                UNUSED_PARAM(actor);
-            };
+            ~BaseState() {};
+            boost::optional<StateMachine::StateChange<Actor>> update(Actor& actor, bool noclip, size_t ticksPassed);
         };
 
     }

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -53,13 +53,10 @@ namespace FAWorld
     {
         if(enemy->isDead() && enemy->mStats != nullptr)
             return false;
-        isAttacking = true;
         Engine::ThreadManager::get()->playSound(FALevelGen::chooseOne({"sfx/misc/swing2.wav", "sfx/misc/swing.wav"}));
         enemy->takeDamage((uint32_t)mStats->getMeleeDamage());
         if(enemy->getCurrentHP() <= 0)
             enemy->die();
-        setAnimation(AnimState::attack, true);
-        mAnimPlaying = true;
         return true;
     }
 

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -101,6 +101,12 @@ add_library(Settings
 target_link_libraries(Settings ${Boost_Libraries})
 set_target_properties(Settings PROPERTIES COMPILE_FLAGS "${FA_COMPILER_FLAGS}")
 
+add_library(StateMachine
+    statemachine/statemachine.h
+)
+target_link_libraries(StateMachine ${Boost_Libraries})
+set_target_properties(StateMachine PROPERTIES COMPILE_FLAGS "${FA_COMPILER_FLAGS}")
+
 add_library(Script
     script/scriptcontext.h
     script/scriptcontext.cpp

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -103,6 +103,7 @@ set_target_properties(Settings PROPERTIES COMPILE_FLAGS "${FA_COMPILER_FLAGS}")
 
 add_library(StateMachine
     statemachine/statemachine.h
+    statemachine/statemachine.cpp
 )
 target_link_libraries(StateMachine ${Boost_Libraries})
 set_target_properties(StateMachine PROPERTIES COMPILE_FLAGS "${FA_COMPILER_FLAGS}")

--- a/components/statemachine/statemachine.cpp
+++ b/components/statemachine/statemachine.cpp
@@ -1,0 +1,1 @@
+#include "statemachine.h"

--- a/components/statemachine/statemachine.h
+++ b/components/statemachine/statemachine.h
@@ -1,0 +1,87 @@
+#ifndef STATEMACHINE_H
+#define STATEMACHINE_H
+
+#include <misc/misc.h>
+#include <vector>
+#include <stddef.h>
+#include <boost/optional.hpp>
+
+namespace StateMachine
+{
+
+    template <typename E> struct StateChange;
+
+    enum StateOperation
+    {
+        pop,
+        push,
+        replace
+    };
+
+    template<typename E>
+    class AbstractState
+    {
+    public:
+        virtual ~AbstractState() {};
+        virtual boost::optional<StateChange<E>> update(E& entity, bool noclip, size_t ticksPassed) = 0;
+        virtual void onEnter(E& entity)
+        {
+                UNUSED_PARAM(entity);
+        };
+        virtual void onExit(E& entity)
+        {
+                UNUSED_PARAM(entity);
+        };
+    };
+
+    template <typename E>
+    struct StateChange
+    {
+        StateChange(StateOperation op):
+            op(op), nextState(nullptr) {};
+        StateChange(StateOperation op, AbstractState<E>* nextState):
+            op(op), nextState(nextState) {};
+        StateOperation op;
+        AbstractState<E>* nextState;
+    };
+
+    template <typename E>
+    class StateMachine
+    {
+    public:
+        StateMachine(AbstractState<E>* initial, E* mEntity): mEntity(mEntity) {
+            mStateStack.push_back(initial);
+        }
+        ~StateMachine() {};
+
+        void update(bool noclip, size_t ticksPassed)
+        {
+            if (!mStateStack.empty()) {
+                if (auto next = mStateStack.back()->update(*mEntity, noclip, ticksPassed)) {
+                    mStateStack.back()->onExit(*mEntity);
+
+                    switch (next->op) {
+                    case StateOperation::pop:
+                        mStateStack.pop_back();
+                        break;
+                    case StateOperation::push:
+                        mStateStack.push_back(next->nextState);
+                    case StateOperation::replace:
+                        mStateStack.pop_back();
+                        mStateStack.push_back(next->nextState);
+                        break;
+                    }
+
+                    mStateStack.back()->onEnter(*mEntity);
+                }
+            }
+        }
+
+    private:
+        std::vector<AbstractState<E>*> mStateStack;
+        E* mEntity;
+    };
+
+}
+
+#endif


### PR DESCRIPTION
The code is still hairy and I used some hacks like friend classes (for now) to enable the first round of refactoring.

Next steps will be to move all the behaviour to their own states and define proper interface to talk to the actor.

So far there is only the "BaseState" (which will turn abstract eventually) doing all the work old `Actor::update` was doing except handling the attack state, I have added a state for that as an example of how simple it can be :)