### PR TITLE
Add factions to support better ally/foe detection.

### DIFF
--- a/apps/freeablo/CMakeLists.txt
+++ b/apps/freeablo/CMakeLists.txt
@@ -1,33 +1,33 @@
 add_library(freeablo_lib # split into a library so I can link to it from tests
-    fa_main.cpp 
+    fa_main.cpp
 
-    falevelgen/levelgen.h 
-    falevelgen/levelgen.cpp 
-    falevelgen/random.cpp 
-    falevelgen/random.h 
-    falevelgen/mst.cpp 
+    falevelgen/levelgen.h
+    falevelgen/levelgen.cpp
+    falevelgen/random.cpp
+    falevelgen/random.h
+    falevelgen/mst.cpp
     falevelgen/mst.h
     falevelgen/tileset.cpp
     falevelgen/tileset.h
-    
+
     farender/renderer.cpp
     farender/renderer.h
     farender/spritecache.cpp
     farender/spritecache.h
     farender/spritemanager.cpp
     farender/spritemanager.h
-    
+
     faworld/actor.cpp
-    faworld/actor.h 
+    faworld/actor.h
     faworld/monster.h
-    faworld/monster.cpp 
-    faworld/player.h  
+    faworld/monster.cpp
+    faworld/player.h
     faworld/player.cpp
     faworld/playerfactory.h
     faworld/playerfactory.cpp
-    faworld/position.h  
+    faworld/position.h
     faworld/position.cpp
-    faworld/world.cpp  
+    faworld/world.cpp
     faworld/world.h
     faworld/inventory.h
     faworld/inventory.cpp
@@ -45,7 +45,9 @@ add_library(freeablo_lib # split into a library so I can link to it from tests
     faworld/gamelevel.h
     faworld/findpath.h
     faworld/findpath.cpp
-    
+    faworld/faction.cpp
+    faworld/faction.h
+
     fagui/guimanager.h
     fagui/guimanager.cpp
     fagui/animateddecorator.h
@@ -70,7 +72,7 @@ add_library(freeablo_lib # split into a library so I can link to it from tests
     engine/inputobserverinterface.h
     engine/enginemain.h
     engine/enginemain.cpp
-    
+
     engine/net/netmanager.cpp
     engine/net/netmanager.h
     engine/net/server.h

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -145,7 +145,7 @@ namespace FAWorld
     ) :
         mPos(pos),
         mFrame(0),
-        mIsEnemy(false),
+        mFaction(Faction::heaven()),
         mAnimState(AnimState::idle)
     {
         if (!dieAnimPath.empty())
@@ -210,9 +210,9 @@ namespace FAWorld
         return mIsDead;
     }
 
-    bool Actor::isEnemy() const
+    bool Actor::isEnemy(Actor* other) const
     {
-        return mIsEnemy;
+        return mFaction.canAttack(other->mFaction);
     }
 
     AnimState::AnimState Actor::getAnimState()
@@ -300,7 +300,7 @@ namespace FAWorld
         if (this == actor)
             return false;
 
-        if (!actor->isEnemy())
+        if (!isEnemy(actor))
             return false;
 
         if (actor->isDead())

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -14,7 +14,7 @@
 #include "position.h"
 #include "gamelevel.h"
 #include "world.h"
-
+#include "faction.h"
 
 namespace Engine
 {
@@ -39,7 +39,7 @@ namespace FAWorld
             hit,
             ENUM_END // always leave this as the last entry, and don't set explicit values for any of the entries
         };
-    }    
+    }
     class Actor : public NetObject
     {
         STATIC_HANDLE_NET_OBJECT_IN_CLASS()
@@ -64,7 +64,7 @@ namespace FAWorld
             virtual FARender::FASpriteGroup* getCurrentAnim();
             void setAnimation(AnimState::AnimState state, bool reset=false);
             void setWalkAnimation(const std::string path);
-            void setIdleAnimation(const std::string path);            
+            void setIdleAnimation(const std::string path);
             AnimState::AnimState getAnimState();
             bool findPath(GameLevelImpl* level, std::pair<int32_t, int32_t> destination);
 
@@ -89,14 +89,14 @@ namespace FAWorld
                 return false;
             }
 
-            Position mPos;            
+            Position mPos;
         //private: //TODO: fix this
             FARender::FASpriteGroup* mWalkAnim = FARender::getDefaultSprite();
             FARender::FASpriteGroup* mIdleAnim = FARender::getDefaultSprite();
             FARender::FASpriteGroup* mDieAnim = FARender::getDefaultSprite();
             FARender::FASpriteGroup* mAttackAnim = FARender::getDefaultSprite();
             FARender::FASpriteGroup* mHitAnim = FARender::getDefaultSprite();
-        
+
             size_t mFrame;
             virtual void die();
             std::pair<int32_t, int32_t> mDestination;
@@ -107,7 +107,7 @@ namespace FAWorld
 
             bool canTalk() const;
             bool isDead() const;
-            bool isEnemy() const;
+            bool isEnemy(Actor* other) const;
             std::string getActorId() const;
             void setActorId(const std::string& id);
             void setCanTalk(bool canTalk);
@@ -209,7 +209,7 @@ namespace FAWorld
 
             bool mIsDead = false;
             bool mCanTalk = false;
-            bool mIsEnemy;
+            Faction mFaction;
 
             friend class boost::serialization::access;
 

--- a/apps/freeablo/faworld/faction.cpp
+++ b/apps/freeablo/faworld/faction.cpp
@@ -1,0 +1,11 @@
+#include "faction.h"
+
+namespace FAWorld
+{
+
+    bool Faction::canAttack(const Faction& other) const
+    {
+        return mFaction != other.mFaction;
+    }
+
+}

--- a/apps/freeablo/faworld/faction.h
+++ b/apps/freeablo/faworld/faction.h
@@ -1,0 +1,41 @@
+#ifndef FACTION_H
+#define FACTION_H
+
+namespace FAWorld
+{
+    class Actor;
+
+    enum FactionType
+    {
+        hell,
+        heaven,
+        ENUM_END
+    };
+
+    // We will use a simple class with a type flag, having this in
+    // "true" OO-style with one class for faction is not worth the
+    // fuss yet as the logic is simple
+    class Faction
+    {
+    public:
+        Faction(FactionType faction): mFaction(faction) {};
+
+        bool canAttack(const Faction& other) const;
+
+        static Faction hell()
+        {
+            return Faction(FactionType::hell);
+        }
+
+        static Faction heaven()
+        {
+            return Faction(FactionType::heaven);
+        }
+
+    private:
+        FactionType mFaction;
+    };
+
+}
+
+#endif

--- a/apps/freeablo/faworld/monster.cpp
+++ b/apps/freeablo/faworld/monster.cpp
@@ -21,7 +21,7 @@ namespace FAWorld
         mAnimTimeMap[AnimState::dead] = FAWorld::World::getTicksInPeriod(0.1f);
         mAnimTimeMap[AnimState::hit] = FAWorld::World::getTicksInPeriod(0.1f);
 
-        mIsEnemy = true;
+        mFaction = Faction::hell();
     }
 
     Monster::Monster()

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -39,6 +39,8 @@ namespace FAWorld
         mAnimTimeMap[AnimState::attack] = FAWorld::World::getTicksInPeriod(0.2f);
         mAnimTimeMap[AnimState::idle] = FAWorld::World::getTicksInPeriod(0.1f);
 
+        mFaction = Faction::heaven();
+
         FAWorld::World::get()->registerPlayer(this);
     }
 


### PR DESCRIPTION
The member variable `mEnemy` on the actor is insufficient because actors can be both players and monsters and possibly other factions (angles, townsfolk...).  I have added factions and resolution of who is an enemy based on that, so that monsters see the player and townsfolk as enemies and they see monsters as enemies.