### PR TITLE
Do not set negative direction

### DIFF
--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -62,7 +62,7 @@ namespace FAWorld
                 if (canIAttack(actor))
                 {
                     std::pair<float, float> vector = Misc::getVec(mPos.current(), mDestination);
-                    mPos.mDirection = Misc::getVecDir(vector);
+                    mPos.setDirection(Misc::getVecDir(vector));
                     mPos.update();
                     mPos.mDist = 0;
 
@@ -107,8 +107,8 @@ namespace FAWorld
                                 mDestination = mPos.current();
                                 setAnimation(AnimState::idle);
                             }
-                            int newDirection = Misc::getVecDir(Misc::getVec(mPos.current(), nextPos));
-                            mPos.mDirection = newDirection == -1 ? mPos.mDirection : newDirection;// we often got the error direction why ?
+
+                            mPos.setDirection(Misc::getVecDir(Misc::getVec(mPos.current(), nextPos)));
                         }
                     }
                 }

--- a/apps/freeablo/faworld/gamelevel.cpp
+++ b/apps/freeablo/faworld/gamelevel.cpp
@@ -131,7 +131,8 @@ namespace FAWorld
 
         for(size_t i = 0; i < mActors.size(); i++)
         {
-            size_t frame = mActors[i]->mFrame + mActors[i]->mPos.mDirection * mActors[i]->getCurrentAnim()->getAnimLength();
+            size_t frame = mActors[i]->mFrame + mActors[i]->mPos.getDirection() * mActors[i]->getCurrentAnim()->getAnimLength();
+
             state->mObjects.push_back(std::tuple<FARender::FASpriteGroup*, size_t, FAWorld::Position>(mActors[i]->getCurrentAnim(), frame, mActors[i]->mPos));
         }
     }

--- a/apps/freeablo/faworld/position.cpp
+++ b/apps/freeablo/faworld/position.cpp
@@ -33,6 +33,17 @@ namespace FAWorld
         }
     }
 
+    int32_t Position::getDirection() const
+    {
+        return mDirection;
+    }
+
+    void Position::setDirection(int32_t mDirection)
+    {
+        if (mDirection >= 0)
+            this->mDirection = mDirection;
+    }
+
     std::pair<int32_t, int32_t> Position::current() const
     {
         return mCurrent;

--- a/apps/freeablo/faworld/position.h
+++ b/apps/freeablo/faworld/position.h
@@ -26,15 +26,18 @@ namespace FAWorld
             std::pair<int32_t, int32_t> pathNext(bool bIncrease ); ///< get the next find path way node.
 
             int32_t mDist; ///< percentage of the way there
-            int32_t mDirection;
+            int32_t getDirection() const;
+            void setDirection(int32_t mDirection);
+
             std::vector<std::pair<int32_t, int32_t>> mPath;  ///< find path result
             std::pair<int32_t, int32_t> mGoal;  ///< the movement goal point. it maybe changed by findPath,otherwise it maybe 0 if findpath failed. It's necessary and different from World::mDestination.
             int mIndex;///< index
             bool mMoving;
             double distanceFrom(Position B);
-        
+
         private:
             std::pair<int32_t, int32_t> mCurrent;
+            int32_t mDirection;
 
             template<class Archive>
             void save(Archive & ar, const unsigned int version) const

--- a/apps/freeablo/faworld/position.h
+++ b/apps/freeablo/faworld/position.h
@@ -26,6 +26,10 @@ namespace FAWorld
             std::pair<int32_t, int32_t> pathNext(bool bIncrease ); ///< get the next find path way node.
 
             int32_t mDist; ///< percentage of the way there
+        private:
+            int32_t mDirection;
+
+        public:
             int32_t getDirection() const;
             void setDirection(int32_t mDirection);
 
@@ -37,7 +41,6 @@ namespace FAWorld
 
         private:
             std::pair<int32_t, int32_t> mCurrent;
-            int32_t mDirection;
 
             template<class Archive>
             void save(Archive & ar, const unsigned int version) const
@@ -64,7 +67,7 @@ namespace FAWorld
 
             BOOST_SERIALIZATION_SPLIT_MEMBER()
 
-            template<class Stream> 
+            template<class Stream>
             Serial::Error::Error faSerial(Stream& stream)
             {
                 serialise_int(stream, 0, 100, mDist);


### PR DESCRIPTION
This

```c++
mPos.mDirection = Misc::getVecDir(vector);
```

could sometimes return `-1` as the direction (if the vector is zero), then this code where we calculate the frame

```c++
size_t frame = mActors[i]->mFrame + mActors[i]->mPos.mDirection * mActors[i]->getCurrentAnim()->getAnimLength();
```

would underflow because size_t is unsigned and give us frame number like 49385894586 which would kill the renderer and crash the program.

I have made the `mDirection` private and check that we are setting correct value in the setter.