### PR TITLE
fix some celview issue on ubuntu

### DIFF
--- a/apps/celview/mainwindow.cpp
+++ b/apps/celview/mainwindow.cpp
@@ -113,7 +113,7 @@ void MainWindow::on_actionExit_triggered()
 
 void MainWindow::on_selectMPQ_clicked()
 {
-    QString tmpFilename = QFileDialog::getOpenFileName(this, tr("Open MPQ"), ".", tr("MPQ Files (*.mpq)"));
+    QString tmpFilename = QFileDialog::getOpenFileName(this, tr("Open MPQ"), ".", tr("MPQ Files (*.mpq *.MPQ)"));
     if (!tmpFilename.isEmpty())
     {
         mFilename = tmpFilename;
@@ -248,6 +248,7 @@ void MainWindow::updateRender()
     if(mCurrentCel->size() > 0)
       Render::drawSprite((SDL_Texture*)(*mCurrentCel)[mCurrentFrame], 0, 0);
     Render::draw();
+    Render::handleEvents();
 }
 
 bool MainWindow::openMPQ()

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -71,6 +71,8 @@ namespace Render
 
     void draw();
 
+    void handleEvents();
+
     void drawSprite(const Sprite& sprite, int32_t x, int32_t y);
 
     struct RocketFATex

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -755,6 +755,16 @@ namespace Render
         // draw points 0-3 from the currently bound VAO with current in-use shader
         glDrawArrays(GL_TRIANGLES, 0, 6);
     }
+
+
+    void handleEvents()
+    {
+        SDL_Event event;
+        while (SDL_PollEvent(&event))
+        {
+            //do nothing, just clear the event queue to avoid render window hang up in ubuntu.
+        }
+    }
     
     void drawSprite(const Sprite& sprite, int32_t x, int32_t y)
     {

--- a/resources/shaders/basic.frag
+++ b/resources/shaders/basic.frag
@@ -1,3 +1,4 @@
+#version 330 core
 in vec2 uv;
 out vec4 frag_colour;
 uniform sampler2D tex;

--- a/resources/shaders/basic.vert
+++ b/resources/shaders/basic.vert
@@ -1,3 +1,4 @@
+#version 330 core
 in vec3 vertex_position;
 in vec2 v_uv;
 out vec2 uv;


### PR DESCRIPTION
1. add sdl event handle to avoid celview render window hang up on ubuntu.
2. add version line in glsl shader to avoid shader errors on ubuntu system.