### PR TITLE
Implemented dummy (for now) panels for inventory, spells etc.

### DIFF
--- a/apps/freeablo/engine/engineinputmanager.cpp
+++ b/apps/freeablo/engine/engineinputmanager.cpp
@@ -228,7 +228,8 @@ namespace Engine
         if(key == Input::KEY_LEFT_MOUSE)
             mMouseDown = false;
 
-        notifyMouseObservers(MOUSE_RELEASE, mMousePosition);
+        if (!nk_item_is_any_active (mNkCtx))
+            notifyMouseObservers(MOUSE_RELEASE, mMousePosition);
     }
 
     void EngineInputManager::mouseMove(int32_t x, int32_t y, int32_t xrel, int32_t yrel)
@@ -301,7 +302,7 @@ namespace Engine
         mInput.processInput(paused);
         nk_input_end(mNkCtx);
 
-        if(!paused && mMouseDown)
+        if(!paused && mMouseDown && !nk_item_is_any_active (mNkCtx))
         {
             notifyMouseObservers(MOUSE_DOWN, mMousePosition);
 

--- a/apps/freeablo/fagui/guimanager.h
+++ b/apps/freeablo/fagui/guimanager.h
@@ -19,20 +19,46 @@ class ElementDocument;
 
 namespace FAGui
 {
+    enum class PanelType {
+        none,
+        inventory,
+        spells,
+        character,
+        quests,
+    };
+
+    enum class PanelPlacement
+    {
+        none,
+        left,
+        right,
+    };
+
+    PanelPlacement panelPlacementByType (PanelType type);
+    const char *bgImgPath (PanelType type);
+    const char *panelName (PanelType type);
 
     class ScrollBox;
     class GuiManager
     {
     public:
-
         GuiManager(Engine::EngineMain& engine);
-
         void update(bool paused, nk_context* ctx);
 
+    private:
+        void togglePanel (PanelType type);
+        template <class Function>
+        void drawPanel(nk_context* ctx, PanelType panelType, Function op);
+        void inventoryPanel(nk_context* ctx);
+        void characterPanel(nk_context* ctx);
+        void questsPanel(nk_context* ctx);
+        void spellsPanel(nk_context* ctx);
+        void bottomMenu(nk_context* ctx);
+        PanelType* panel(PanelPlacement placement);
 
     private:
-
         Engine::EngineMain& mEngine;
+        PanelType mCurRightPanel, mCurLeftPanel;
     };
 }
 


### PR DESCRIPTION
The first commit blocks events handled by nuklear so that character walk etc. is not triggered when we click on various panels.

The second - adds dummy panels. The only problem with panels is that in original game they are drawn under the bottom panel (it's visible by health/mana bubble) and nuklear seems to force active windows on top so their order is changing if they are clicked. Probable workaround of attaching `NK_WINDOW_BACKGROUND` to them somehow breaks event handling so in the future it needs to be investigated further. 