### PR TITLE
Make use of animation sequences specified for some towners.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ if(MSVC)
     # 4459 - declaration of 'self' hides global declaration
     # 4127 - conditional expression is constant, could be useful to check that both branches compilable.
     # 4800 - forcing value to bool, stupid warning
+    set(FA_COMPILER_FLAGS "${FA_COMPILER_FLAGS} /w44062")
+    # 4061 - not all enumerator values are handled by the switch statement
     if (TREAT_WARNINGS_AS_ERRORS)
         set(FA_COMPILER_FLAGS "${FA_COMPILER_FLAGS} /WX")
     endif()

--- a/apps/freeablo/farender/animationplayer.h
+++ b/apps/freeablo/farender/animationplayer.h
@@ -15,6 +15,7 @@ namespace FARender
                 Looped,
                 Once,
                 FreezeAtEnd,
+                BySequence,
 
                 ENUM_END
             };
@@ -22,7 +23,8 @@ namespace FARender
             AnimationPlayer() {}
 
             std::pair<FARender::FASpriteGroup*, int32_t> getCurrentFrame();
-            void playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick duration, AnimationType type);
+            void playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick frameDuration, AnimationType type);
+            void playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick frameDuration, std::vector<int> frameSequence);
 
             //!
             //! Simply replaces the currently running animation.
@@ -39,6 +41,7 @@ namespace FARender
             FAWorld::Tick mPlayingAnimDuration = 0;
             AnimationType mPlayingAnimType = AnimationType::Once;
             FAWorld::Tick mTicksSinceAnimStarted = 0;
+            std::vector<int> mFrameSequence;
 
             template <class Stream>
             Serial::Error::Error faSerial(Stream& stream)

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -17,6 +17,11 @@ namespace FAWorld
 {
     STATIC_HANDLE_NET_OBJECT_IN_IMPL(Actor)
 
+    void Actor::setIdleAnimSequence(const std::vector<int>& sequence)
+    {
+        mAnimation.setIdleFrameSequence (sequence);
+    }
+
     void Actor::update(bool noclip)
     {
         if (!isDead())

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -46,6 +46,7 @@ namespace FAWorld
     {
         STATIC_HANDLE_NET_OBJECT_IN_CLASS()
         void interact(Actor* actor);
+        void setIdleAnimSequence(const std::vector<int> & sequence);
         friend class ActorState::BaseState; // TODO: fix
 
         public:

--- a/apps/freeablo/faworld/actoranimationmanager.cpp
+++ b/apps/freeablo/faworld/actoranimationmanager.cpp
@@ -10,11 +10,8 @@ namespace FAWorld
         for (AnimState s = (AnimState)0; s < AnimState::ENUM_END; s = (AnimState)(((int32_t)s) + 1))
         {
             mAnimations[s] = FARender::getDefaultSprite();
-            mAnimTimeMap[s] = World::getTicksInPeriod(0.5f);
+            mAnimTimeMap[s] = World::getTicksInPeriod(0.06f);
         }
-
-        mAnimTimeMap[AnimState::attack] = World::getTicksInPeriod(1.0f);
-        mAnimTimeMap[AnimState::idle] = World::getTicksInPeriod(1.0f);
     }
 
     AnimState ActorAnimationManager::getCurrentAnimation()
@@ -31,6 +28,12 @@ namespace FAWorld
     {
         mPlayingAnim = animation;
         mAnimationPlayer.playAnimation(mAnimations[animation], mAnimTimeMap[animation], type);
+    }
+
+    void ActorAnimationManager::playAnimation(AnimState animation, std::vector<int> frameSequence)
+    {
+        mPlayingAnim = animation;
+        mAnimationPlayer.playAnimation(mAnimations[animation], mAnimTimeMap[animation], frameSequence);
     }
 
     void ActorAnimationManager::setAnimation(AnimState animation, FARender::FASpriteGroup* sprite)
@@ -50,6 +53,16 @@ namespace FAWorld
 
         // loop idle animation if we're not doing anything else
         if (sprite == nullptr)
-            playAnimation(AnimState::idle, FARender::AnimationPlayer::AnimationType::Looped);
+        {
+            if (mIdleFrameSequence.empty ())
+                playAnimation(AnimState::idle, FARender::AnimationPlayer::AnimationType::Looped);
+            else
+                playAnimation(AnimState::idle, mIdleFrameSequence);
+        }
+    }
+
+    void ActorAnimationManager::setIdleFrameSequence(const std::vector<int>& sequence)
+    {
+        mIdleFrameSequence = sequence;
     }
 }

--- a/apps/freeablo/faworld/actoranimationmanager.h
+++ b/apps/freeablo/faworld/actoranimationmanager.h
@@ -28,9 +28,11 @@ namespace FAWorld
         std::pair<FARender::FASpriteGroup*, int32_t> getCurrentRealFrame();
 
         void playAnimation(AnimState animation, FARender::AnimationPlayer::AnimationType type);
+        void playAnimation(AnimState animation, std::vector<int> frameSequence);
         void setAnimation(AnimState animation, FARender::FASpriteGroup* sprite);
 
         void update();
+        void setIdleFrameSequence(const std::vector<int>& sequence);
 
     private:
         AnimState mPlayingAnim = AnimState::none;
@@ -38,6 +40,7 @@ namespace FAWorld
 
         std::unordered_map<AnimState, FARender::FASpriteGroup*, EnumClassHash> mAnimations;
         std::map<AnimState, Tick> mAnimTimeMap;
+        std::vector<int> mIdleFrameSequence;
 
         template <class Stream>
         Serial::Error::Error faSerial(Stream& stream)

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -143,6 +143,8 @@ namespace FAWorld
         for (size_t i = 0; i < npcs.size(); i++)
         {
             Actor* actor = new Actor(npcs[i]->celPath, npcs[i]->celPath);
+            if (auto id = npcs[i]->animationSequenceId)
+                actor->setIdleAnimSequence (mDiabloExe.getTownerAnimation()[*id]);
             actor->setCanTalk(true);
             actor->setActorId(npcs[i]->id);
             actor->setName (npcs[i]->name);

--- a/components/diabloexe/diabloexe.h
+++ b/components/diabloexe/diabloexe.h
@@ -19,6 +19,7 @@ namespace DiabloExe
     class DiabloExe
     {
         public:
+
             DiabloExe(const std::string& pathEXE = "Diablo.exe");
 
             const Monster& getMonster(const std::string& name) const;
@@ -26,6 +27,7 @@ namespace DiabloExe
 
             const Npc& getNpc(const std::string& name) const;
             std::vector<const Npc*> getNpcs() const;
+            const std::vector<std::vector<int32_t>> &getTownerAnimation() const;
 
             const BaseItem& getItem(const std::string& name) const;
             std::map<std::string, BaseItem> getItemMap() const;
@@ -51,6 +53,7 @@ namespace DiabloExe
             void loadUniqueItems(FAIO::FAFileObject& exe);
             void loadAffixes(FAIO::FAFileObject& exe);
             void loadCharacterStats(FAIO::FAFileObject& exe);
+            void loadTownerAnimation(FAIO::FAFileObject& exe);
 
 
 
@@ -63,6 +66,7 @@ namespace DiabloExe
             std::map<std::string, UniqueItem> mUniqueItems;
             std::map<std::string, Affix> mAffixes;
             std::map<std::string, CharacterStats> mCharacters;
+            std::vector<std::vector<int32_t>> mTownerAnimation;
     };
 }
 

--- a/components/diabloexe/npc.h
+++ b/components/diabloexe/npc.h
@@ -2,6 +2,7 @@
 #define EXE_NPC_H
 
 #include <faio/fafileobject.h>
+#include <boost/optional/optional.hpp>
 
 namespace DiabloExe
 {
@@ -14,6 +15,7 @@ namespace DiabloExe
             uint8_t x;
             uint8_t y;
             size_t rotation;
+            boost::optional<int32_t> animationSequenceId;
 
             Npc() {}
 

--- a/resources/exeversions/v109.ini
+++ b/resources/exeversions/v109.ini
@@ -26,18 +26,24 @@ maxStatsOffset=650788
 expPerLevelOffset=650840
 maxLevel=50
 
+[TownerAnimation]
+offset=722212
+size=148
+count = 6
 
 [NPCsmith]
 name=723908
 cel=723932
 x=390943
 y=390941
+animationId=0
 
 [NPCtavern]
 name=723960
 cel= 723984
 x=391093
 y=391091
+animationId=3
 
 [NPCwounded]
 name=724008
@@ -51,6 +57,7 @@ name=724056
 cel=724072
 x=391381
 y=391379
+animationId=5
 
 [NPCmaid]
 name=724100
@@ -69,18 +76,21 @@ name=724176
 cel=724196
 x=391816
 y=391814
+animationId=1
 
 [NPCstorytell]
 name=724224
 cel=724240
 x=391960
 y=391958
+animationId=2
 
 [NPCdrunk]
 name=660196
 cel=724272
 x=392103
 y=392101
+animationId=4
 
 [NPCcow1]
 name=724300


### PR DESCRIPTION
So most of the towners have hardcoded animation sequences (sequences of frames) in game because sometimes their animation takes complex repeating pattern. This patch should extract them from diablo.exe and apply to towners which use it.

The other change I made is to make `animationPlayer` accept duration of single frame rather than duration of the whole animation. I think that originally Diablo has the similar timing in regards to animation (each frames takes roughly the same time). Since some of these sequences rather long it would be really bothersome to specify length of each animation manually. Also attack duration seems to look fine this way without previously applied fix, so I think it should be correct.