### PR TITLE
fix bug with hit animation

### DIFF
--- a/apps/freeablo/farender/animationplayer.cpp
+++ b/apps/freeablo/farender/animationplayer.cpp
@@ -40,13 +40,13 @@ namespace FARender
         return std::make_pair(mCurrentAnim, currentFrame);
     }
 
-    void AnimationPlayer::playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick frameDuration, AnimationPlayer::AnimationType type)
+    void AnimationPlayer::playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick frameDuration, AnimationPlayer::AnimationType type, int32_t startFrame)
     {
         mCurrentAnim = anim;
         mPlayingAnimDuration = frameDuration;
 
         mPlayingAnimType = type;
-        mTicksSinceAnimStarted = 0;
+        mTicksSinceAnimStarted = frameDuration * startFrame;
     }
 
     void AnimationPlayer::playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick frameDuration, std::vector<int> frameSequence)

--- a/apps/freeablo/farender/animationplayer.h
+++ b/apps/freeablo/farender/animationplayer.h
@@ -23,7 +23,9 @@ namespace FARender
             AnimationPlayer() {}
 
             std::pair<FARender::FASpriteGroup*, int32_t> getCurrentFrame();
-            void playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick frameDuration, AnimationType type);
+            AnimationType getCurrentAnimationType() { return mPlayingAnimType; }
+
+            void playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick frameDuration, AnimationType type, int32_t startFrame = 0);
             void playAnimation(FARender::FASpriteGroup* anim, FAWorld::Tick frameDuration, std::vector<int> frameSequence);
 
             //!

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -28,12 +28,6 @@ namespace FAWorld
         {
             if (getLevel())
             {
-                if (isAttacking)
-                {
-                    if (getAnimationManager().getCurrentAnimation() != AnimState::attack)
-                        isAttacking = false;
-                }
-
                 mActorStateMachine->update(noclip);
             }
 
@@ -87,7 +81,9 @@ namespace FAWorld
         if (!(mStats->getCurrentHP() <= 0))
         {
             Engine::ThreadManager::get()->playSound(getHitWav());
-            mAnimation.playAnimation(AnimState::hit, FARender::AnimationPlayer::AnimationType::Once);
+
+            if (mAnimation.getCurrentAnimation() != AnimState::hit)
+                mAnimation.interruptAnimation(AnimState::hit, FARender::AnimationPlayer::AnimationType::Once);
         }
     }
 

--- a/apps/freeablo/faworld/actor/attackstate.cpp
+++ b/apps/freeablo/faworld/actor/attackstate.cpp
@@ -11,8 +11,13 @@ namespace FAWorld
         {
             UNUSED_PARAM(noclip);
 
-            if (actor.getAnimationManager().getCurrentAnimation() != AnimState::attack)
+            auto& animManager = actor.getAnimationManager();
+            if (animManager.getCurrentAnimation() != AnimState::attack && animManager.getInterruptedAnimation() != AnimState::attack)
+            {
+                actor.isAttacking = false;
                 return StateMachine::StateChange<Actor>{StateMachine::StateOperation::pop};
+            }
+
 
             return boost::none;
         }

--- a/apps/freeablo/faworld/actor/basestate.cpp
+++ b/apps/freeablo/faworld/actor/basestate.cpp
@@ -25,15 +25,15 @@ namespace FAWorld
                     if(!actor.getPos().isNear(target->getPos()))
                         actor.mMoveHandler.setDestination(target->getPos().current());
                     else // and interact them if in range
+                    {
+                        if (actor.canIAttack(target) && actor.attack(target))
                         {
-                            if (actor.canIAttack(target) && actor.attack(target))
-                            {
-                              ret = StateMachine::StateChange<Actor>{StateMachine::StateOperation::push, new AttackState()};
-                            }
-                            else if (actor.canTalkTo(target) && actor.talk(target)) {
-
-                            }
+                          ret = StateMachine::StateChange<Actor>{StateMachine::StateOperation::push, new AttackState()};
                         }
+                        else if (actor.canTalkTo(target) && actor.talk(target)) {
+
+                        }
+                    }
                 }
                 else
                 {

--- a/apps/freeablo/faworld/actoranimationmanager.cpp
+++ b/apps/freeablo/faworld/actoranimationmanager.cpp
@@ -24,6 +24,15 @@ namespace FAWorld
         return mAnimationPlayer.getCurrentFrame();
     }
 
+    void ActorAnimationManager::interruptAnimation(AnimState animation, FARender::AnimationPlayer::AnimationType type)
+    {
+        mInterruptedAnimationState = mPlayingAnim;
+        mInterruptedAnimationFrame = mAnimationPlayer.getCurrentFrame().second;
+        mInterruptedAnimationType = mAnimationPlayer.getCurrentAnimationType();
+
+        playAnimation(animation, type);
+    }
+
     void ActorAnimationManager::playAnimation(AnimState animation, FARender::AnimationPlayer::AnimationType type)
     {
         mPlayingAnim = animation;
@@ -54,10 +63,21 @@ namespace FAWorld
         // loop idle animation if we're not doing anything else
         if (sprite == nullptr)
         {
-            if (mIdleFrameSequence.empty ())
-                playAnimation(AnimState::idle, FARender::AnimationPlayer::AnimationType::Looped);
+            if (mInterruptedAnimationState != AnimState::none)
+            {
+                mPlayingAnim = mInterruptedAnimationState;
+                mAnimationPlayer.playAnimation(mAnimations[mPlayingAnim], mAnimTimeMap[mPlayingAnim], mInterruptedAnimationType, mInterruptedAnimationFrame);
+
+                mInterruptedAnimationState = AnimState::none;
+                mInterruptedAnimationFrame = 0;
+            }
             else
-                playAnimation(AnimState::idle, mIdleFrameSequence);
+            {
+                if (mIdleFrameSequence.empty ())
+                    playAnimation(AnimState::idle, FARender::AnimationPlayer::AnimationType::Looped);
+                else
+                    playAnimation(AnimState::idle, mIdleFrameSequence);
+            }
         }
     }
 

--- a/apps/freeablo/faworld/actoranimationmanager.h
+++ b/apps/freeablo/faworld/actoranimationmanager.h
@@ -25,14 +25,19 @@ namespace FAWorld
         ActorAnimationManager();
 
         AnimState getCurrentAnimation();
+        AnimState getInterruptedAnimation() { return mInterruptedAnimationState; }
+
         std::pair<FARender::FASpriteGroup*, int32_t> getCurrentRealFrame();
 
         void playAnimation(AnimState animation, FARender::AnimationPlayer::AnimationType type);
         void playAnimation(AnimState animation, std::vector<int> frameSequence);
+        void interruptAnimation(AnimState animation, FARender::AnimationPlayer::AnimationType type);
+
         void setAnimation(AnimState animation, FARender::FASpriteGroup* sprite);
 
         void update();
         void setIdleFrameSequence(const std::vector<int>& sequence);
+
 
     private:
         AnimState mPlayingAnim = AnimState::none;
@@ -41,6 +46,13 @@ namespace FAWorld
         std::unordered_map<AnimState, FARender::FASpriteGroup*, EnumClassHash> mAnimations;
         std::map<AnimState, Tick> mAnimTimeMap;
         std::vector<int> mIdleFrameSequence;
+
+        // TODO: we could probably do with making this a stack, but it's good enough for now
+        // At time of writing (5/Nov/17), it's just used for hit animations, which don't need a stack
+        AnimState mInterruptedAnimationState = AnimState::none;
+        FARender::AnimationPlayer::AnimationType mInterruptedAnimationType;
+        int32_t mInterruptedAnimationFrame = 0;
+
 
         template <class Stream>
         Serial::Error::Error faSerial(Stream& stream)


### PR DESCRIPTION
an attack is considered "over" when the attack animation is complete.
This was being checked by comparing the actor's current animation
to the attack animation. However, if the actor is hit during the attack
animation, they play the hit animation, which marks the attack as done.
This lets them attack again immediately. Here, I change d this behaviour,
so the attack will resume after the hit anim, and you can't attack again
until it's really finished.