### PR TITLE
Load path to dropping animation from exe instead of hardcoding.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,13 +73,14 @@ if(UNIX)
 endif()
 
 if(MSVC)
-    set(FA_COMPILER_FLAGS "${FA_COMPILER_FLAGS} /W4 /D_CRT_SECURE_NO_WARNINGS /wd4244 /wd4100 /wd4611 /wd4458 /wd4459 /wd4127 /wd4800")
+    set(FA_COMPILER_FLAGS "${FA_COMPILER_FLAGS} /W4 /D_CRT_SECURE_NO_WARNINGS /wd4244 /wd4100 /wd4611 /wd4458 /wd4459 /wd4127 /wd4800 /wd4267")
     # 4244 - e.g. 'argument': conversion from 'const long double' to 'double' -- boost headers
     # 4100 - unreferenced formal parameter -- boost headers
     # 4611 - interaction between '_setjmp' and C++ object destruction is non-portable -- savepng.cpp
     # 4458 - shadow for class member -- librocket headers
     # 4459 - declaration of 'self' hides global declaration
     # 4127 - conditional expression is constant, could be useful to check that both branches compilable.
+    # 4267 -  conversion from 'size_t' to 'int', possible loss of data -- too many such warnings in 64-bit build currently
     # 4800 - forcing value to bool, stupid warning
     set(FA_COMPILER_FLAGS "${FA_COMPILER_FLAGS} /w44062")
     # 4061 - not all enumerator values are handled by the switch statement

--- a/apps/exedump/main.cpp
+++ b/apps/exedump/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include <faio/fafileobject.h>
+#include "settings/settings.h"
 
 int main(int, char**)
 {

--- a/apps/freeablo/faworld/actorstats.cpp
+++ b/apps/freeablo/faworld/actorstats.cpp
@@ -1,8 +1,34 @@
 #include "actorstats.h"
 #include "../falevelgen/random.h"
 #include "item.h"
+#include "diabloexe/characterstats.h"
+
 namespace FAWorld
 {
+    ActorStats::ActorStats(DiabloExe::CharacterStats stats):
+                                                           mExpForLevel(stats.mNextLevelExp)
+                                                           , mLevel(1)
+                                                           , mLevelPoints(0)
+                                                           , mExp(0)
+                                                           , mExpToNextLevel(2000)
+                                                           , mStartingVitality(stats.mVitality)
+                                                           , mMaxVitality(stats.mMaxVitality)
+                                                           , mStartingMagic(stats.mMagic)
+                                                           , mMaxMagic(stats.mMaxMagic)
+                                                           , mStartingDexterity(stats.mDexterity)
+                                                           , mMaxDexterity(stats.mMaxDexterity)
+                                                           , mStartingStrength(stats.mStrength)
+                                                           , mMaxStrength(stats.mMaxStrength)
+                                                           , mBlockingBonus(stats.mBlockingBonus)
+                                                           , mAttackFrameset(stats.mAttackFrameset)
+                                                           , mAttackSpeed(stats.mSingleHandedAttackSpeed)
+    {
+        mVitality = mStartingVitality;
+        mStrength = mStartingStrength;
+        mMagic = mStartingMagic;
+        mDexterity = mStartingDexterity;
+        recalculateDerivedStats();
+    }
 
     ActorStats::ActorStats(const DiabloExe::Monster &monsterStat)
         : mMaxVitality(0), mMaxMagic(0),
@@ -123,7 +149,7 @@ namespace FAWorld
     uint8_t ActorStats::getAttackSpeed()
     {
         return mAttackSpeed;
-    } 
+    }
 
     uint8_t ActorStats::getAttackFrameset()
     {

--- a/apps/freeablo/faworld/actorstats.h
+++ b/apps/freeablo/faworld/actorstats.h
@@ -8,6 +8,11 @@
 #include "actor.h"
 
 
+namespace DiabloExe
+{
+    class CharacterStats;
+}
+
 namespace FAWorld
 {
 
@@ -43,31 +48,7 @@ namespace FAWorld
 
             void setActor(Actor * actor){mActor = actor;}
 
-            ActorStats(DiabloExe::CharacterStats stats) :
-                mExpForLevel(stats.mNextLevelExp),
-                mLevel(1),
-                mLevelPoints(0),
-                mExp(0),
-                mExpToNextLevel(2000),
-                mStartingVitality(stats.mVitality),
-                mMaxVitality(stats.mMaxVitality),
-                mStartingMagic(stats.mMagic),
-                mMaxMagic(stats.mMaxMagic),
-                mStartingDexterity(stats.mDexterity),
-                mMaxDexterity(stats.mMaxDexterity),
-                mStartingStrength(stats.mStrength),
-                mMaxStrength(stats.mMaxStrength),
-                mBlockingBonus(stats.mBlockingBonus),
-                mAttackFrameset(stats.mAttackFrameset),
-                mAttackSpeed(stats.mSingleHandedAttackSpeed)
-
-            {
-                mVitality = mStartingVitality;
-                mStrength = mStartingStrength;                
-                mMagic    = mStartingMagic;
-                mDexterity = mStartingDexterity;
-                recalculateDerivedStats();
-            }
+        ActorStats(DiabloExe::CharacterStats stats);
             ActorStats(const DiabloExe::Monster & monsterStat);
 
             virtual void printStats();

--- a/apps/freeablo/faworld/characterstats.cpp
+++ b/apps/freeablo/faworld/characterstats.cpp
@@ -9,7 +9,7 @@ namespace FAWorld
 
         std::vector<std::tuple<Item::ItemEffect, uint32_t, uint32_t, uint32_t>> effects;
         effects = mPlayer->getInventory ().getTotalEffects();
-        printf("%lu -- size of effects\n", effects.size());
+        printf("%zu -- size of effects\n", effects.size());
         for(std::vector<std::tuple<Item::ItemEffect, uint32_t, uint32_t, uint32_t>>::iterator it= effects.begin();it != effects.end(); ++it)
         {
             Item::ItemEffect effect;

--- a/apps/freeablo/faworld/characterstats.cpp
+++ b/apps/freeablo/faworld/characterstats.cpp
@@ -1,8 +1,14 @@
 #include "characterstats.h"
 #include "player.h"
 #include "../falevelgen/random.h"
+#include "diabloexe/characterstats.h"
+
 namespace FAWorld
 {
+    CharacterStatsBase::CharacterStatsBase(DiabloExe::CharacterStats stats, Player* player): ActorStats(stats)
+                                                                                           , mPlayer(player)
+    {
+    }
 
     void CharacterStatsBase::processEffects()
     {
@@ -300,6 +306,14 @@ namespace FAWorld
     }
 
 
+    MeleeStats::MeleeStats(DiabloExe::CharacterStats stats, Player* player): CharacterStatsBase(stats, player)
+    {
+        mHP = 2 * mVitality + 2 * mLevel + 18;
+        mCurrentHP = mHP;
+        mMana = mMagic + mLevel - 1;
+        mCurrentMana = mMana;
+    }
+
     void MeleeStats::recalculateDerivedStats()
     {
         clearDerivedStats();
@@ -323,6 +337,14 @@ namespace FAWorld
         mChanceToHitArrow += 10;
     }
 
+    RangerStats::RangerStats(DiabloExe::CharacterStats stats, Player* player): CharacterStatsBase(stats, player)
+    {
+        mHP = mVitality + 2 * mLevel + 23;
+        mCurrentHP = mHP;
+        mMana = mMagic + 2 * mLevel + 5;
+        mCurrentMana = mMana;
+    }
+
     void RangerStats::recalculateDerivedStats()
     {
         clearDerivedStats();
@@ -344,6 +366,14 @@ namespace FAWorld
         mDamageDoneBow   += mPlayer->getInventory ().getTotalAttackDamage();
         mArmourClass += mPlayer->getInventory ().getTotalArmourClass();
         mChanceToHitArrow += 20;
+    }
+
+    MageStats::MageStats(DiabloExe::CharacterStats stats, Player* player): CharacterStatsBase(stats, player)
+    {
+        mHP = mVitality + 2 * mLevel + 9;
+        mCurrentHP = mHP;
+        mMana = 2 * mMagic + 2 * mLevel - 2;
+        mCurrentMana = mMana;
     }
 
     void MageStats::recalculateDerivedStats()

--- a/apps/freeablo/faworld/characterstats.h
+++ b/apps/freeablo/faworld/characterstats.h
@@ -2,6 +2,11 @@
 #define DIABLOCHARACTERSTATS_H
 #include "actorstats.h"
 
+namespace DiabloExe
+{
+  class CharacterStats;
+}
+
 namespace FAWorld
 {
     class Inventory;
@@ -10,7 +15,7 @@ namespace FAWorld
     class CharacterStatsBase : public ActorStats
     {
         public:
-            CharacterStatsBase(DiabloExe::CharacterStats stats, Player * player) : ActorStats(stats), mPlayer(player){}
+        CharacterStatsBase(DiabloExe::CharacterStats stats, Player* player);
             virtual void processEffects();
 
         protected:
@@ -21,13 +26,7 @@ namespace FAWorld
     class MeleeStats : public CharacterStatsBase
     {
     public:
-        MeleeStats(DiabloExe::CharacterStats stats, Player * player) : CharacterStatsBase(stats, player)
-        {
-            mHP = 2*mVitality + 2*mLevel+18;
-            mCurrentHP = mHP;
-            mMana = mMagic + mLevel -1;
-            mCurrentMana = mMana;
-        }
+        MeleeStats(DiabloExe::CharacterStats stats, Player* player);
         void recalculateDerivedStats() final;
     private:
 
@@ -38,13 +37,7 @@ namespace FAWorld
     class RangerStats : public CharacterStatsBase
     {
         public:
-            RangerStats(DiabloExe::CharacterStats stats, Player * player) : CharacterStatsBase(stats, player)
-            {
-                mHP = mVitality + 2*mLevel+23;
-                mCurrentHP = mHP;
-                mMana = mMagic + 2*mLevel +5;
-                mCurrentMana = mMana;
-            }
+        RangerStats(DiabloExe::CharacterStats stats, Player* player);
 
             void recalculateDerivedStats() final;
         private:
@@ -57,13 +50,7 @@ namespace FAWorld
     {
         public:
 
-            MageStats(DiabloExe::CharacterStats stats, Player * player) : CharacterStatsBase(stats, player)
-            {
-                mHP = mVitality + 2*mLevel + 9;
-                mCurrentHP = mHP;
-                mMana = 2*mMagic + 2*mLevel -2;
-                mCurrentMana = mMana;
-            }
+        MageStats(DiabloExe::CharacterStats stats, Player* player);
             void recalculateDerivedStats() final;
         private:
             friend class Inventory;

--- a/apps/freeablo/faworld/gamelevel.h
+++ b/apps/freeablo/faworld/gamelevel.h
@@ -8,7 +8,6 @@
 
 #include <misc/stdhashes.h>
 #include "hoverstate.h"
-#include "item.h"
 
 namespace FARender
 {

--- a/apps/freeablo/faworld/item.cpp
+++ b/apps/freeablo/faworld/item.cpp
@@ -83,6 +83,7 @@ Item::Item(DiabloExe::BaseItem item, uint32_t id, DiabloExe::Affix* affix, bool 
     mUseOnce  = item.useOnce;
     mBuyPrice = item.price1;
     mSellPrice= item.price2;
+    mDropItemGraphicsPath = item.dropItemGraphicsPath;
 
     if(mType != itGOLD)
     {
@@ -203,33 +204,7 @@ std::pair<uint8_t, uint8_t> Item::getCornerCoords() const
 
 std::string Item::getFlipAnimationPath() const
 {
-    // TODO: extract mapping from exe
-    switch (getCode())
-    {
-        case icOther:
-            switch (getType())
-            {
-                case itPOT: return "items/fbttle.cel";
-            default:
-                break;
-            }
-            break;
-        case icSword: return "items/swrdflip.cel";
-        case icAxe: return "items/axe.cel";
-        case icBow: return "items/bow.cel";
-        case icBlunt: return "items/mace.cel";
-        case icShield: return "items/shield.cel";
-        case icLightArmour: return "items/larmor.cel";
-        case icHelm: return "items/helmut.cel";
-        case icMidArmour: return "items/armor2.cel";
-        case icHeavyArmour: return "items/FPlateAr.cel";
-        case icStave: return "items/staff.cel";
-        case icGold: return "items/goldflip.cel";
-        case icRing:
-        case icAmulet:
-            return "items/ring.cel";
-    }
-    return "";
+    return mDropItemGraphicsPath;
 }
 
 std::string Item::getFlipSoundPath() const

--- a/apps/freeablo/faworld/item.h
+++ b/apps/freeablo/faworld/item.h
@@ -300,7 +300,7 @@ private:
     uint8_t mSizeY;
 
     static bool mObjcursLoaded;
-
+    std::string mDropItemGraphicsPath;
 };
 }
 #endif // ITEM_H

--- a/apps/freeablo/faworld/itemmanager.cpp
+++ b/apps/freeablo/faworld/itemmanager.cpp
@@ -1,4 +1,6 @@
 #include "itemmanager.h"
+#include "item.h"
+
 #include <sstream>
 #include <iostream>
 #include <unordered_map>

--- a/apps/freeablo/faworld/itemmanager.h
+++ b/apps/freeablo/faworld/itemmanager.h
@@ -1,7 +1,6 @@
 #ifndef ITEMMANAGER_H
 #define ITEMMANAGER_H
 
-#include "item.h"
 #include <map>
 #include <stdint.h>
 #include <diabloexe/diabloexe.h>
@@ -13,8 +12,8 @@ namespace Engine
     class EngineMain;
 }
 namespace FAWorld
-
 {
+    class Item;
 
     class ItemPosition
     {

--- a/apps/freeablo/faworld/monster.h
+++ b/apps/freeablo/faworld/monster.h
@@ -5,7 +5,7 @@
 
 namespace DiabloExe
 {
-    struct Monster;
+    class  Monster;
 }
 
 namespace FAWorld

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -7,6 +7,7 @@
 #include <misc/stringops.h>
 #include <string>
 #include "itemmap.h"
+#include "diabloexe/characterstats.h"
 
 namespace FAWorld
 {

--- a/apps/freeablo/faworld/playerfactory.cpp
+++ b/apps/freeablo/faworld/playerfactory.cpp
@@ -2,6 +2,7 @@
 #include "player.h"
 #include "characterstats.h"
 #include "itemmanager.h"
+#include "diabloexe/characterstats.h"
 
 namespace FAWorld
 {

--- a/apps/freeablo/faworld/playerfactory.cpp
+++ b/apps/freeablo/faworld/playerfactory.cpp
@@ -71,7 +71,7 @@ void PlayerFactory::createWarrior(Player* player) const
     player->setSpriteClass("warrior");
     player->getAnimationManager().setAnimation(AnimState::idle, FARender::Renderer::get()->loadImage("plrgfx/warrior/wld/wldst.cl2"));
     player->getAnimationManager().setAnimation(AnimState::walk, FARender::Renderer::get()->loadImage("plrgfx/warrior/wld/wldwl.cl2"));
-    //loadTestingKit (player);
+    loadTestingKit (player);
 }
 
 void PlayerFactory::createRogue(Player* player) const

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -16,6 +16,7 @@
 #include "gamelevel.h"
 #include "findpath.h"
 #include "itemmap.h"
+#include "diabloexe/npc.h"
 
 namespace FAWorld
 {

--- a/components/diabloexe/affix.h
+++ b/components/diabloexe/affix.h
@@ -11,7 +11,7 @@
 namespace DiabloExe
 {
     //Affix -- Part of a word or phrase can be before or after the object Prefix for before Suffix for afterwords.
-    struct Affix
+    class Affix
     {
     public:
 

--- a/components/diabloexe/baseitem.h
+++ b/components/diabloexe/baseitem.h
@@ -47,6 +47,8 @@ namespace DiabloExe
         uint32_t price1;
         uint32_t price2;
 
+        std::string dropItemGraphicsPath;
+
         std::string dump() const;
         BaseItem();
 

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -44,10 +44,10 @@ namespace DiabloExe
         loadTownerAnimation(exe);
         loadNpcs(exe);
         loadCharacterStats(exe);
+        loadDropGraphicsFilenames (exe, codeOffset);
         loadBaseItems(exe, codeOffset);
         loadUniqueItems(exe, codeOffset);
         loadAffixes(exe, codeOffset);
-        loadDropGraphicsFilenames (exe, codeOffset);
     }
 
     DiabloExe::~DiabloExe()
@@ -212,6 +212,12 @@ namespace DiabloExe
     {
         size_t itemOffset = mSettings->get<size_t>("BaseItems","itemOffset");
         size_t count = mSettings->get<size_t>("BaseItems","count");
+        size_t itemGraphicsIdToDropGraphicsIdOffset = mSettings->get<size_t>("ItemDropGraphics","itemGraphicsIdToDropGraphicsId");
+        std::vector<size_t> itemGraphicsIdToDropGraphicsId (172);
+
+        exe.FAfseek(itemGraphicsIdToDropGraphicsIdOffset, SEEK_SET);
+        for (auto &el : itemGraphicsIdToDropGraphicsId)
+            el = exe.read8();
 
         for(size_t i=0; i < count; i++)
         {
@@ -224,6 +230,8 @@ namespace DiabloExe
                 continue;
             if(Misc::StringUtils::containsNonPrint(tmp.itemSecondName))
                 continue;
+
+            tmp.dropItemGraphicsPath = "items/" + itemDropGraphicsFilename[itemGraphicsIdToDropGraphicsId[tmp.graphicValue]] + ".cel";
             if(mBaseItems.find(tmp.itemName) != mBaseItems.end())
             {
                 size_t j;

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -39,13 +39,14 @@ namespace DiabloExe
             return;
         }
 
-        loadMonsters(exe);
+        auto codeOffset = mSettings->get<size_t>("General", "codeOffset");
+        loadMonsters(exe, codeOffset);
         loadTownerAnimation(exe);
         loadNpcs(exe);
         loadCharacterStats(exe);
-        loadBaseItems(exe);
-        loadUniqueItems(exe);
-        loadAffixes(exe);
+        loadBaseItems(exe, codeOffset);
+        loadUniqueItems(exe, codeOffset);
+        loadAffixes(exe, codeOffset);
     }
 
     DiabloExe::~DiabloExe()
@@ -125,10 +126,9 @@ namespace DiabloExe
         return version;
     }
 
-    void DiabloExe::loadMonsters(FAIO::FAFileObject& exe)
+    void DiabloExe::loadMonsters(FAIO::FAFileObject& exe, size_t codeOffset)
     {
         size_t monsterOffset = mSettings->get<size_t>("Monsters", "monsterOffset");
-        size_t codeOffset = mSettings->get<size_t>("Monsters", "codeOffset");
         size_t count = mSettings->get<size_t>("Monsters", "count");
 
         for(size_t i = 0; i < count; i++)
@@ -196,10 +196,9 @@ namespace DiabloExe
         }
     }
 
-    void DiabloExe::loadBaseItems(FAIO::FAFileObject& exe)
+    void DiabloExe::loadBaseItems(FAIO::FAFileObject& exe, size_t codeOffset)
     {
         size_t itemOffset = mSettings->get<size_t>("BaseItems","itemOffset");
-        size_t codeOffset = mSettings->get<size_t>("BaseItems","codeOffset");
         size_t count = mSettings->get<size_t>("BaseItems","count");
 
         for(size_t i=0; i < count; i++)
@@ -226,10 +225,9 @@ namespace DiabloExe
             }
         }
     }
-    void DiabloExe::loadUniqueItems(FAIO::FAFileObject& exe)
+    void DiabloExe::loadUniqueItems(FAIO::FAFileObject& exe, size_t codeOffset)
     {
         size_t itemOffset = mSettings->get<size_t>("UniqueItems","uniqueItemOffset");
-        size_t codeOffset = mSettings->get<size_t>("UniqueItems","codeOffset");
         size_t count = mSettings->get<size_t>("UniqueItems","count");
 
         for(size_t i=0; i < count; i++)
@@ -286,10 +284,9 @@ namespace DiabloExe
         }
     }
 
-    void DiabloExe::loadAffixes(FAIO::FAFileObject& exe)
+    void DiabloExe::loadAffixes(FAIO::FAFileObject& exe, size_t codeOffset)
     {
         size_t affixOffset = mSettings->get<size_t>("Affix","affixOffset");
-        size_t codeOffset = mSettings->get<size_t>("Affix","codeOffset");
         size_t count = mSettings->get<size_t>("Affix","count");
 
 

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -20,7 +20,7 @@ namespace DiabloExe
 {
     DiabloExe::DiabloExe(const std::string& pathEXE)
     {
-        mSettings = std::make_unique<Settings::Settings> ();
+        mSettings.reset (new Settings::Settings ());
         mVersion = getVersion(pathEXE);
         if (mVersion.empty())
         {
@@ -131,7 +131,7 @@ namespace DiabloExe
     {
         auto offset = mSettings->get<size_t>("ItemDropGraphics", "filenames");
         itemDropGraphicsFilename.resize (35);
-        for(int i = 0; i < itemDropGraphicsFilename.size (); ++i) {
+        for(int i = 0; i < static_cast<int> (itemDropGraphicsFilename.size ()); ++i) {
             exe.FAfseek(offset + i * 4, SEEK_SET);
             auto nameOffset = exe.read32();
             itemDropGraphicsFilename[i] = exe.readCStringFromWin32Binary(nameOffset, codeOffset);

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -9,17 +9,25 @@
 #include <misc/md5.h>
 #include <misc/stringops.h>
 
+#include "settings/settings.h"
+#include "monster.h"
+#include "npc.h"
+#include "baseitem.h"
+#include "characterstats.h"
+#include "../../apps/freeablo/faworld/item.h"
+
 namespace DiabloExe
 {
     DiabloExe::DiabloExe(const std::string& pathEXE)
     {
+        mSettings = std::make_unique<Settings::Settings> ();
         mVersion = getVersion(pathEXE);
         if (mVersion.empty())
         {
             return;
         }
 
-        if(!mSettings.loadFromFile("resources/exeversions/" + mVersion + ".ini"))
+        if(!mSettings->loadFromFile("resources/exeversions/" + mVersion + ".ini"))
         {
             std::cout << "Cannot load settings file.";
             return;
@@ -38,6 +46,10 @@ namespace DiabloExe
         loadBaseItems(exe);
         loadUniqueItems(exe);
         loadAffixes(exe);
+    }
+
+    DiabloExe::~DiabloExe()
+    {
     }
 
 
@@ -115,9 +127,9 @@ namespace DiabloExe
 
     void DiabloExe::loadMonsters(FAIO::FAFileObject& exe)
     {
-        size_t monsterOffset = mSettings.get<size_t>("Monsters", "monsterOffset");
-        size_t codeOffset = mSettings.get<size_t>("Monsters", "codeOffset");
-        size_t count = mSettings.get<size_t>("Monsters", "count");
+        size_t monsterOffset = mSettings->get<size_t>("Monsters", "monsterOffset");
+        size_t codeOffset = mSettings->get<size_t>("Monsters", "codeOffset");
+        size_t count = mSettings->get<size_t>("Monsters", "count");
 
         for(size_t i = 0; i < count; i++)
         {
@@ -141,9 +153,9 @@ namespace DiabloExe
 
     void DiabloExe::loadTownerAnimation(FAIO::FAFileObject& exe)
     {
-        auto offset = mSettings.get<int32_t>("TownerAnimation","offset");
-        auto size = mSettings.get<int32_t>("TownerAnimation","size");
-        auto count = mSettings.get<int32_t>("TownerAnimation","count");
+        auto offset = mSettings->get<int32_t>("TownerAnimation","offset");
+        auto size = mSettings->get<int32_t>("TownerAnimation","size");
+        auto count = mSettings->get<int32_t>("TownerAnimation","count");
         exe.FAfseek(offset, SEEK_SET);
         mTownerAnimation.resize (count);
         for (int32_t i = 0; i < count; ++i) {
@@ -163,7 +175,7 @@ namespace DiabloExe
 
     void DiabloExe::loadNpcs(FAIO::FAFileObject& exe)
     {
-        Settings::Container sections = mSettings.getSections();
+        Settings::Container sections = mSettings->getSections();
 
         for(Settings::Container::const_iterator it = sections.begin(); it != sections.end(); ++it)
         {
@@ -174,10 +186,10 @@ namespace DiabloExe
             {
                 auto &curNpc = mNpcs[name.substr(3, name.size()-3)];
                  curNpc =
-                    Npc(exe, name, mSettings.get<size_t>(section, "name"), mSettings.get<size_t>(section, "cel"),
-                        mSettings.get<size_t>(section, "x"), mSettings.get<size_t>(section, "y"), mSettings.get<size_t>(section, "rotation", 0));
+                    Npc(exe, name, mSettings->get<size_t>(section, "name"), mSettings->get<size_t>(section, "cel"),
+                        mSettings->get<size_t>(section, "x"), mSettings->get<size_t>(section, "y"), mSettings->get<size_t>(section, "rotation", 0));
 
-                auto animId = mSettings.get<int32_t>(section, "animationId", -1);
+                auto animId = mSettings->get<int32_t>(section, "animationId", -1);
                 if (animId >= 0)
                     curNpc.animationSequenceId = animId;
             }
@@ -186,9 +198,9 @@ namespace DiabloExe
 
     void DiabloExe::loadBaseItems(FAIO::FAFileObject& exe)
     {
-        size_t itemOffset = mSettings.get<size_t>("BaseItems","itemOffset");
-        size_t codeOffset = mSettings.get<size_t>("BaseItems","codeOffset");
-        size_t count = mSettings.get<size_t>("BaseItems","count");
+        size_t itemOffset = mSettings->get<size_t>("BaseItems","itemOffset");
+        size_t codeOffset = mSettings->get<size_t>("BaseItems","codeOffset");
+        size_t count = mSettings->get<size_t>("BaseItems","count");
 
         for(size_t i=0; i < count; i++)
         {
@@ -216,9 +228,9 @@ namespace DiabloExe
     }
     void DiabloExe::loadUniqueItems(FAIO::FAFileObject& exe)
     {
-        size_t itemOffset = mSettings.get<size_t>("UniqueItems","uniqueItemOffset");
-        size_t codeOffset = mSettings.get<size_t>("UniqueItems","codeOffset");
-        size_t count = mSettings.get<size_t>("UniqueItems","count");
+        size_t itemOffset = mSettings->get<size_t>("UniqueItems","uniqueItemOffset");
+        size_t codeOffset = mSettings->get<size_t>("UniqueItems","codeOffset");
+        size_t count = mSettings->get<size_t>("UniqueItems","count");
 
         for(size_t i=0; i < count; i++)
         {
@@ -276,9 +288,9 @@ namespace DiabloExe
 
     void DiabloExe::loadAffixes(FAIO::FAFileObject& exe)
     {
-        size_t affixOffset = mSettings.get<size_t>("Affix","affixOffset");
-        size_t codeOffset = mSettings.get<size_t>("Affix","codeOffset");
-        size_t count = mSettings.get<size_t>("Affix","count");
+        size_t affixOffset = mSettings->get<size_t>("Affix","affixOffset");
+        size_t codeOffset = mSettings->get<size_t>("Affix","codeOffset");
+        size_t count = mSettings->get<size_t>("Affix","count");
 
 
         for(size_t i=0; i < count; i++)
@@ -305,12 +317,12 @@ namespace DiabloExe
 
     void DiabloExe::loadCharacterStats(FAIO::FAFileObject& exe)
     {
-        size_t startingStatsOffset = mSettings.get<size_t>("CharacterStats", "startingStatsOffset");
-        size_t maxStatsOffset = mSettings.get<size_t>("CharacterStats", "maxStatsOffset");
-        size_t blockingBonusOffset = mSettings.get<size_t>("CharacterStats", "blockingBonusOffset");
-        size_t framesetOffset = mSettings.get<size_t>("CharacterStats", "framesetOffset");
-        size_t expPerLevelOffset = mSettings.get<size_t>("CharacterStats", "expPerLevelOffset");
-        size_t levelCount = mSettings.get<size_t>("CharacterStats", "maxLevel");
+        size_t startingStatsOffset = mSettings->get<size_t>("CharacterStats", "startingStatsOffset");
+        size_t maxStatsOffset = mSettings->get<size_t>("CharacterStats", "maxStatsOffset");
+        size_t blockingBonusOffset = mSettings->get<size_t>("CharacterStats", "blockingBonusOffset");
+        size_t framesetOffset = mSettings->get<size_t>("CharacterStats", "framesetOffset");
+        size_t expPerLevelOffset = mSettings->get<size_t>("CharacterStats", "expPerLevelOffset");
+        size_t levelCount = mSettings->get<size_t>("CharacterStats", "maxLevel");
         CharacterStats meleeCharacter, rangerCharacter, mageCharacter;
 
         exe.FAfseek(framesetOffset, SEEK_SET);

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -39,7 +39,7 @@ namespace DiabloExe
             return;
         }
 
-        auto codeOffset = mSettings->get<size_t>("General", "codeOffset");
+        auto codeOffset = mSettings->get<size_t>("Common", "codeOffset");
         loadMonsters(exe, codeOffset);
         loadTownerAnimation(exe);
         loadNpcs(exe);
@@ -47,6 +47,7 @@ namespace DiabloExe
         loadBaseItems(exe, codeOffset);
         loadUniqueItems(exe, codeOffset);
         loadAffixes(exe, codeOffset);
+        loadDropGraphicsFilenames (exe, codeOffset);
     }
 
     DiabloExe::~DiabloExe()
@@ -124,6 +125,17 @@ namespace DiabloExe
             std::cout << "Diablo.exe " << version << " detected" << std::endl;
 
         return version;
+    }
+
+    void DiabloExe::loadDropGraphicsFilenames(FAIO::FAFileObject& exe, size_t codeOffset)
+    {
+        auto offset = mSettings->get<size_t>("ItemDropGraphics", "filenames");
+        itemDropGraphicsFilename.resize (35);
+        for(int i = 0; i < itemDropGraphicsFilename.size (); ++i) {
+            exe.FAfseek(offset + i * 4, SEEK_SET);
+            auto nameOffset = exe.read32();
+            itemDropGraphicsFilename[i] = exe.readCStringFromWin32Binary(nameOffset, codeOffset);
+        }
     }
 
     void DiabloExe::loadMonsters(FAIO::FAFileObject& exe, size_t codeOffset)

--- a/components/diabloexe/diabloexe.h
+++ b/components/diabloexe/diabloexe.h
@@ -4,23 +4,30 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <memory>
 
-#include <settings/settings.h>
 #include <faio/fafileobject.h>
 
-#include "monster.h"
-#include "npc.h"
-#include "baseitem.h"
-#include "affix.h"
-#include "uniqueitem.h"
-#include "characterstats.h"
+namespace Settings
+{
+    class Settings;
+}
+
 namespace DiabloExe
 {
+    class Monster;
+    class Npc;
+    class BaseItem;
+    class CharacterStats;
+    class UniqueItem;
+    class Affix;
+
     class DiabloExe
     {
         public:
 
             DiabloExe(const std::string& pathEXE = "Diablo.exe");
+            ~DiabloExe ();
 
             const Monster& getMonster(const std::string& name) const;
             std::vector<const Monster*> getMonstersInLevel(size_t levelNum) const;
@@ -55,9 +62,7 @@ namespace DiabloExe
             void loadCharacterStats(FAIO::FAFileObject& exe);
             void loadTownerAnimation(FAIO::FAFileObject& exe);
 
-
-
-            Settings::Settings mSettings;
+            std::unique_ptr<Settings::Settings> mSettings;
 
             std::string mVersion;
             std::map<std::string, Monster> mMonsters;

--- a/components/diabloexe/diabloexe.h
+++ b/components/diabloexe/diabloexe.h
@@ -54,11 +54,11 @@ namespace DiabloExe
             std::string getVersion(const std::string& pathEXE);
 
 
-            void loadMonsters(FAIO::FAFileObject& exe);
+            void loadMonsters(FAIO::FAFileObject& exe, size_t codeOffset);
             void loadNpcs(FAIO::FAFileObject& exe);
-            void loadBaseItems(FAIO::FAFileObject& exe);
-            void loadUniqueItems(FAIO::FAFileObject& exe);
-            void loadAffixes(FAIO::FAFileObject& exe);
+            void loadBaseItems(FAIO::FAFileObject& exe, size_t codeOffset);
+            void loadUniqueItems(FAIO::FAFileObject& exe, size_t codeOffset);
+            void loadAffixes(FAIO::FAFileObject& exe, size_t codeOffset);
             void loadCharacterStats(FAIO::FAFileObject& exe);
             void loadTownerAnimation(FAIO::FAFileObject& exe);
 

--- a/components/diabloexe/diabloexe.h
+++ b/components/diabloexe/diabloexe.h
@@ -54,6 +54,7 @@ namespace DiabloExe
             std::string getVersion(const std::string& pathEXE);
 
 
+            void loadDropGraphicsFilenames(FAIO::FAFileObject& exe, size_t codeOffset);
             void loadMonsters(FAIO::FAFileObject& exe, size_t codeOffset);
             void loadNpcs(FAIO::FAFileObject& exe);
             void loadBaseItems(FAIO::FAFileObject& exe, size_t codeOffset);
@@ -72,6 +73,7 @@ namespace DiabloExe
             std::map<std::string, Affix> mAffixes;
             std::map<std::string, CharacterStats> mCharacters;
             std::vector<std::vector<int32_t>> mTownerAnimation;
+            std::vector<std::string> itemDropGraphicsFilename;
     };
 }
 

--- a/components/diabloexe/monster.h
+++ b/components/diabloexe/monster.h
@@ -14,7 +14,7 @@ namespace FAIO
 
 namespace DiabloExe
 {
-    struct Monster
+    class Monster
     {
         public:
             uint32_t animSize;
@@ -23,17 +23,17 @@ namespace DiabloExe
             uint32_t secondAttack;
             std::string soundPath; // uint32_t ptr in exe
             uint32_t specialSound;
-            
+
             uint32_t usesTrn;
             std::string trnPath; // uint32_t p
-            
+
             uint32_t idleFrameSet;
             uint32_t walkFrameSet;
             uint32_t attackFrameSet;
             uint32_t recoveryFrameSet;
             uint32_t deathFrameSet;
             uint32_t secondAttackFrameSet;
-            
+
             uint32_t idlePlayback;
             uint32_t walkPlayback;
             uint32_t attackPlayback;
@@ -45,21 +45,21 @@ namespace DiabloExe
 
             uint8_t minDunLevel;
             uint8_t maxDunLevel;
-            
+
             uint16_t level;
 
             uint32_t minHp;
             uint32_t maxHp;
 
             uint8_t attackType;
-            
+
             uint8_t unknown1;
             uint8_t unknown2;
             uint8_t unknown3;
             uint8_t unknown4;
-            
+
             uint8_t intelligence;
-            
+
             uint8_t unknown5;
             uint8_t unknown6;
 
@@ -69,7 +69,7 @@ namespace DiabloExe
             uint8_t hitFrame;
             uint8_t minDamage;
             uint8_t maxDamage;
-            
+
             uint8_t toHitSecond;
             uint8_t hitFrameSecond;
             uint8_t minDamageSecond;
@@ -81,16 +81,16 @@ namespace DiabloExe
 
             uint16_t normalResistanceImmunitiesFlags;
             uint16_t hellResistanceImmunitiesFlags;
-            
+
             uint16_t drops;
 
             uint16_t selectionOutline;
-            
+
             uint32_t exp;
 
             std::string dump() const;
 
-            Monster() {} 
+            Monster() {}
 
         private:
             Monster(FAIO::FAFileObject& exe, size_t codeOffset);

--- a/resources/exeversions/v109.ini
+++ b/resources/exeversions/v109.ini
@@ -25,6 +25,12 @@ maxStatsOffset=0x9EE24
 expPerLevelOffset=0x9EE58
 maxLevel=50
 
+[ItemDropGraphics]
+itemGraphicsIdToDropGraphicsId=0x90A38
+filenames=0x90AE4
+frameCounts=0x90B70
+itemGraphicsIdToSfxId=0x90B94
+
 [TownerAnimation]
 offset=0xB0524
 size=0x94

--- a/resources/exeversions/v109.ini
+++ b/resources/exeversions/v109.ini
@@ -1,21 +1,21 @@
 [Monsters]
 monsterOffset=613384
 count=112
-codeOffset=4203008
+codeOffset=0x402200
 
 [BaseItems]
 itemOffset=578568
-codeOffset=4203008
+codeOffset=0x402200
 count=200
 
 [UniqueItems]
 uniqueItemOffset=506984
-codeOffset=4203008
+codeOffset=0x402200
 count=88
 
 [Affix]
 affixOffset=498344
-codeOffset=4203008
+codeOffset=0x402200
 count=180
 
 [CharacterStats]

--- a/resources/exeversions/v109.ini
+++ b/resources/exeversions/v109.ini
@@ -1,114 +1,113 @@
-[Monsters]
-monsterOffset=613384
-count=112
+[Common]
 codeOffset=0x402200
+
+[Monsters]
+monsterOffset=0x95C08
+count=0x70
 
 [BaseItems]
-itemOffset=578568
-codeOffset=0x402200
-count=200
+itemOffset=0x8D408
+count=0xC8
 
 [UniqueItems]
-uniqueItemOffset=506984
-codeOffset=0x402200
-count=88
+uniqueItemOffset=0x7BC68
+count=0x58
 
 [Affix]
-affixOffset=498344
-codeOffset=0x402200
-count=180
+affixOffset=0x79AA8
+count=0xB4
 
 [CharacterStats]
-framesetOffset=650632
-startingStatsOffset=650713
-blockingBonusOffset=650767
-maxStatsOffset=650788
-expPerLevelOffset=650840
+framesetOffset=0x9ED88
+startingStatsOffset=0x9EDD9
+blockingBonusOffset=0x9EE0F
+maxStatsOffset=0x9EE24
+expPerLevelOffset=0x9EE58
 maxLevel=50
 
 [TownerAnimation]
-offset=722212
-size=148
+offset=0xB0524
+size=0x94
 count = 6
 
 [NPCsmith]
-name=723908
-cel=723932
-x=390943
-y=390941
+name=0xB0BC4
+cel=0xB0BDC
+x=0x5F71F
+y=0x5F71D
 animationId=0
 
 [NPCtavern]
-name=723960
-cel= 723984
-x=391093
-y=391091
+name=0xB0BF8
+cel= 0xB0C10
+x=0x5F7B5
+y=0x5F7B3
 animationId=3
 
 [NPCwounded]
-name=724008
-name_dead=724328
-cel=724028
-x=391237
-y=391235
+name=0xB0C28
+name_dead=0xB0D68
+cel=0xB0C3C
+x=0x5F845
+y=0x5F843
 
 [NPCwitch]
-name=724056
-cel=724072
-x=391381
-y=391379
+name=0xB0C58
+cel=0xB0C68
+x=0x5F8D5
+y=0x5F8D3
 animationId=5
 
 [NPCmaid]
-name=724100
-cel=724120
-x=391524
-y=391522
+name=0xB0C84
+cel=0xB0C98
+x=0x5F964
+y=0x5F962
 
 [NPCboy]
-name=659748
-cel=724148
-x=391670
-y=391667
+name=0xA1124
+cel=0xB0CB4
+x=0x5F9F6
+y=0x5F9F3
 
 [NPChealer]
-name=724176
-cel=724196
-x=391816
-y=391814
+name=0xB0CD0
+cel=0xB0CE4
+x=0x5FA88
+y=0x5FA86
 animationId=1
 
 [NPCstorytell]
-name=724224
-cel=724240
-x=391960
-y=391958
+name=0xB0D00
+cel=0xB0D10
+x=0x5FB18
+y=0x5FB16
 animationId=2
 
 [NPCdrunk]
-name=660196
-cel=724272
-x=392103
-y=392101
+name=0xA12E4
+cel=0xB0D30
+x=0x5FBA7
+y=0x5FBA5
 animationId=4
 
 [NPCcow1]
-name=724300
-cel=724304
-x=723100
-y=723112
+name=0xB0D4C
+cel=0xB0D50
+x=0xB089C
+y=0xB08A8
 rotation=1
 
 [NPCcow2]
-name=724300
-cel=724304
-x=723104
-y=723116
+name=0xB0D4C
+cel=0xB0D50
+x=0xB08A0
+y=0xB08AC
 rotation=3
 
 [NPCcow3]
-name=724300
-cel=724304
-x=723108
-y=723120
+name=0xB0D4C
+cel=0xB0D50
+x=0xB08A4
+y=0xB08B0
 rotation=4


### PR DESCRIPTION
While doing that I also supported reading offsets in exe from .ini in '0x123ABCD' form and converted all the current offsets. This is just a stylistic change but make things a bit more readable in my opinion.

The change itself is also not hard - there is a list of possible dropping animations in .exe and mapping from index of inventory item picture to index in that list.
The same could be done with sounds in the future.