### PR TITLE
Optimization: Remove allocation/push backs during texture decoding.

### DIFF
--- a/apps/celview/main.cpp
+++ b/apps/celview/main.cpp
@@ -9,6 +9,7 @@
 #include <faio/fafileobject.h>
 #include <chrono>
 #include <nfd.h>
+#include "../components/settings/settings.h"
 
 
 int main(int, char**)

--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -10,6 +10,7 @@
 #include <nuklearmisc/widgets.h>
 #include <faio/faio.h>
 #include <climits>
+#include "../components/settings/settings.h"
 
 int main(int, char** argv)
 {

--- a/components/cel/celdecoder.h
+++ b/components/cel/celdecoder.h
@@ -11,6 +11,7 @@
 
 namespace Cel
 {
+    class Pal;
     class CelDecoder
     {
     public:
@@ -24,7 +25,8 @@ namespace Cel
         typedef std::vector<uint8_t> FrameBytes;
         typedef const std::vector<uint8_t>& FrameBytesRef;
         typedef std::vector<Colour>& ColoursRef;
-        typedef std::function<void(CelDecoder&, FrameBytesRef, const Pal&, ColoursRef)> FrameDecoder;
+        typedef std::vector<Colour>::iterator ColoursRefIterator;
+        typedef std::function<void(CelDecoder&, FrameBytesRef, const Pal&, ColoursRefIterator&)> FrameDecoder;
 
         void readConfiguration();
         void readCelName();
@@ -37,23 +39,23 @@ namespace Cel
         bool isType2or4(FrameBytesRef frame);
         bool isType3or5(FrameBytesRef frame);
 
-        void decodeFrameType0(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame);
-        void decodeFrameType1(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame);
-        void decodeFrameType2(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame);
-        void decodeFrameType3(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame);
-        void decodeFrameType4(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame);
-        void decodeFrameType5(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame);
-        void decodeFrameType6(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame);
-        void decodeFrameType2or3(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame, bool frameType2);
-        void decodeFrameType4or5(FrameBytesRef frame, const Pal& pal, ColoursRef decodedFrame, bool frameType4);
+        void decodeFrameType0(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame);
+        void decodeFrameType1(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame);
+        void decodeFrameType2(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame);
+        void decodeFrameType3(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame);
+        void decodeFrameType4(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame);
+        void decodeFrameType5(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame);
+        void decodeFrameType6(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame);
+        void decodeFrameType2or3(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame, bool frameType2);
+        void decodeFrameType4or5(FrameBytesRef frame, const Pal& pal, ColoursRefIterator& decodedFrame, bool frameType4);
 
         void decodeLineTransparencyLeft(const uint8_t** framePtr,
                                         const Pal& pal,
-                                        ColoursRef decodedFrame,
+                                        ColoursRefIterator &decodedFrame,
                                         int);
         void decodeLineTransparencyRight(const uint8_t** framePtr,
                                         const Pal& pal,
-                                        ColoursRef decodedFrame,
+                                        ColoursRefIterator &decodedFrame,
                                         int);
         void setObjcursCelDimensions(int frame);
         void setCharbutCelDimensions(int frame);

--- a/components/cel/celfile.h
+++ b/components/cel/celfile.h
@@ -2,9 +2,6 @@
 #define CEL_FILE_H
 
 #include <stdint.h>
-#include <vector>
-#include <map>
-#include "pal.h"
 #include "celframe.h"
 #include "celdecoder.h"
 

--- a/components/cel/celframe.cpp
+++ b/components/cel/celframe.cpp
@@ -1,10 +1,11 @@
 #include "celframe.h"
+#include "pal.h"
 
 namespace Cel
 {
     const Colour& get(int32_t x, int32_t y, const CelFrame& frame)
     {
-        return frame.mRawImage[x + (frame.mHeight-1-y)*frame.mWidth];
+        return frame.mRawImage.data()[x + (frame.mHeight-1-y)*frame.mWidth];
     }
      
     Misc::Helper2D<const CelFrame, const Colour&> CelFrame::operator[] (int32_t x) const

--- a/components/cel/celframe.h
+++ b/components/cel/celframe.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 #include <vector>
 #include <misc/helper2d.h>
-#include "pal.h"
 
 namespace Cel
 {

--- a/components/cel/pal.cpp
+++ b/components/cel/pal.cpp
@@ -23,6 +23,6 @@ namespace Cel
 
     const Colour& Pal::operator[](size_t index) const
     {
-        return contents[index];
+        return contents.data()[index];
     }
 }

--- a/components/cel/pal.h
+++ b/components/cel/pal.h
@@ -18,8 +18,7 @@ namespace Cel
         {
             r = _r; g = _g; b = _b; visible = _visible;
         }
-
-        Colour(){ visible = true; }
+        Colour () { visible = true; }
     };
 
 

--- a/components/render/levelobjects.h
+++ b/components/render/levelobjects.h
@@ -1,9 +1,15 @@
+#ifndef LEVEL_OBJ_H
+#define LEVEL_OBJ_H
+
 #include "render.h"
 
 #include <misc/helper2d.h>
+#include <boost/optional.hpp>
 
-#ifndef LEVEL_OBJ_H
-#define LEVEL_OBJ_H
+namespace Cel
+{
+    struct Colour;
+}
 
 namespace Render
 {

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -10,10 +10,10 @@
 
 #include <functional>
 
-#include <cel/celfile.h>
-#include <cel/celframe.h>
-
 #include "misc.h"
+
+#include "cel/pal.h"
+#include <boost/optional.hpp>
 
 struct SDL_Cursor;
 struct SDL_Surface;
@@ -30,6 +30,11 @@ namespace Render
         topLeft,
         center,
     };
+}
+
+namespace Cel
+{
+    struct Colour;
 }
 
 #include "levelobjects.h"

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -45,7 +45,7 @@ namespace Render
     int32_t HEIGHT = 960;
 
     SDL_Window* screen;
-    SDL_Renderer* renderer;
+    SDL_Renderer* renderer; 
     SDL_GLContext glContext;
 
     void init(const std::string& title, const RenderSettings& settings, NuklearGraphicsContext& nuklearGraphics, nk_context* nk_ctx)
@@ -1000,8 +1000,9 @@ namespace Render
         {
             for(int32_t y = 0; y < frame.mHeight; y++)
             {
-                if(frame[x][y].visible)
-                    setpixel(s, start_x+x, start_y+y, frame[x][y]);
+                auto &c = frame[x][y];
+                if(c.visible)
+                    setpixel(s, start_x+x, start_y+y, c);
             }
         }
     }


### PR DESCRIPTION
Reduces startup time on windows with MSVC's ITERATOR_DEBUG_LEVEL=2.

By the way assert which I commented fails somewhere. I didn't check where yet but looks like some image might have incorrect size.