### PR TITLE
Update Hunter version. Fixes MSVC release build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(UNIX)
 endif()
 
 if(MSVC)
-    set(FA_COMPILER_FLAGS "${FA_COMPILER_FLAGS} /W4 /D_CRT_SECURE_NO_WARNINGS /wd4244 /wd4100 /wd4611 /wd4458 /wd4459 /wd4127 /wd4800 /wd4267")
+    set(FA_COMPILER_FLAGS "${FA_COMPILER_FLAGS} /MP /W4 /D_CRT_SECURE_NO_WARNINGS /wd4244 /wd4100 /wd4611 /wd4458 /wd4459 /wd4127 /wd4800 /wd4267")
     # 4244 - e.g. 'argument': conversion from 'const long double' to 'double' -- boost headers
     # 4100 - unreferenced formal parameter -- boost headers
     # 4611 - interaction between '_setjmp' and C++ object destruction is non-portable -- savepng.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required (VERSION 2.8.11)
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.19.131.tar.gz"
-    SHA1 "bc0eec34712af8854085c2dc6a90b78df17a9743"
+    URL "https://github.com/ruslo/hunter/archive/v0.19.178.tar.gz"
+    SHA1 "1b94f895831f76e5a63e0537dd366ae142543c02"
     LOCAL
 )
 


### PR DESCRIPTION
I also appened /MP for Visual Studio, maybe it will improve AppVeyor build speed a bit.