### PR TITLE
now using #pragma instead of header guards, fixed spacing formating, too, on all H's @Hydroque

### DIFF
--- a/apps/freeablo/engine/engineinputmanager.h
+++ b/apps/freeablo/engine/engineinputmanager.h
@@ -1,5 +1,5 @@
-#ifndef FA_INPUT_H
-#define FA_INPUT_H
+
+#pragma once
 
 #include "../components/misc/misc.h"
 #include "../faworld/actoranimationmanager.h"
@@ -65,4 +65,3 @@ namespace Engine
     };
 }
 
-#endif // FA_INPUT_H

--- a/apps/freeablo/engine/enginemain.h
+++ b/apps/freeablo/engine/enginemain.h
@@ -1,5 +1,6 @@
-#ifndef ENGINEMAIN_H
-#define ENGINEMAIN_H
+
+#pragma once
+
 #include "../faworld/playerfactory.h"
 #include "engineinputmanager.h"
 #include <boost/program_options.hpp>
@@ -55,4 +56,3 @@ namespace Engine
     };
 }
 
-#endif // ENGINEMAIN_H

--- a/apps/freeablo/engine/inputobserverinterface.h
+++ b/apps/freeablo/engine/inputobserverinterface.h
@@ -1,5 +1,5 @@
-#ifndef FA_INPUT_OBSERVER_INTERFACE
-#define FA_INPUT_OBSERVER_INTERFACE
+
+#pragma once
 
 namespace Misc
 {
@@ -46,4 +46,3 @@ namespace Engine
     };
 }
 
-#endif

--- a/apps/freeablo/engine/threadmanager.h
+++ b/apps/freeablo/engine/threadmanager.h
@@ -1,5 +1,5 @@
-#ifndef THREAD_MANAGER_H
-#define THREAD_MANAGER_H
+
+#pragma once
 
 #include <boost/lockfree/spsc_queue.hpp>
 #include <string>
@@ -59,4 +59,3 @@ namespace Engine
     };
 }
 
-#endif

--- a/apps/freeablo/faaudio/audiomanager.h
+++ b/apps/freeablo/faaudio/audiomanager.h
@@ -1,5 +1,5 @@
-#ifndef AUDIO_MANAGER_H
-#define AUDIO_MANAGER_H
+
+#pragma once
 
 #include <audio/audio.h>
 #include <list>
@@ -45,4 +45,3 @@ namespace FAAudio
     };
 }
 
-#endif

--- a/apps/freeablo/fagui/autocomplete.h
+++ b/apps/freeablo/fagui/autocomplete.h
@@ -1,5 +1,5 @@
-#ifndef AUTOCOMPLETE_H
-#define AUTOCOMPLETE_H
+
+#pragma once
 
 #include <iostream>
 #include <map>
@@ -52,4 +52,3 @@ namespace FAGui
     };
 }
 
-#endif

--- a/apps/freeablo/fagui/commandhistory.h
+++ b/apps/freeablo/fagui/commandhistory.h
@@ -1,5 +1,5 @@
-#ifndef COMMAND_HISTORY_H
-#define COMMAND_HISTORY_H
+
+#pragma once
 
 #include <iterator>
 #include <list>
@@ -28,4 +28,3 @@ namespace FAGui
     };
 }
 
-#endif

--- a/apps/freeablo/fagui/dialogmanager.h
+++ b/apps/freeablo/fagui/dialogmanager.h
@@ -1,4 +1,6 @@
+
 #pragma once
+
 #include <array>
 #include <functional>
 #include <string>
@@ -69,3 +71,4 @@ namespace FAGui
         FAWorld::World& mWorld;
     };
 }
+

--- a/apps/freeablo/fagui/guimanager.h
+++ b/apps/freeablo/fagui/guimanager.h
@@ -1,5 +1,6 @@
-#ifndef GUIMANAGER_H
-#define GUIMANAGER_H
+
+#pragma once
+
 #include "textcolor.h"
 #include <chrono>
 #include <functional>
@@ -140,4 +141,3 @@ namespace FAGui
     };
 }
 
-#endif

--- a/apps/freeablo/fagui/menu/menuscreen.h
+++ b/apps/freeablo/fagui/menu/menuscreen.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <functional>
@@ -54,3 +55,4 @@ namespace FAGui
         int mActiveItemIndex = 0;
     };
 }
+

--- a/apps/freeablo/fagui/menu/pausemenuscreen.h
+++ b/apps/freeablo/fagui/menu/pausemenuscreen.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <cstdint>
@@ -34,3 +35,4 @@ namespace FAGui
         int activeItemIndex = 0;
     };
 }
+

--- a/apps/freeablo/fagui/menu/selectheromenuscreen.h
+++ b/apps/freeablo/fagui/menu/selectheromenuscreen.h
@@ -1,4 +1,6 @@
+
 #pragma once
+
 #include "menuscreen.h"
 #include <boost/optional.hpp>
 #include <memory>
@@ -63,3 +65,4 @@ namespace FAGui
         int activeItemIndex = 0;
     };
 }
+

--- a/apps/freeablo/fagui/menu/startingmenuscreen.h
+++ b/apps/freeablo/fagui/menu/startingmenuscreen.h
@@ -1,4 +1,6 @@
+
 #pragma once
+
 #include "menuscreen.h"
 #include <memory>
 
@@ -24,3 +26,4 @@ namespace FAGui
         std::unique_ptr<FARender::AnimationPlayer> mFocus42;
     };
 }
+

--- a/apps/freeablo/fagui/menuhandler.h
+++ b/apps/freeablo/fagui/menuhandler.h
@@ -1,4 +1,6 @@
+
 #pragma once
+
 #include <memory>
 
 namespace DiabloExe
@@ -51,3 +53,4 @@ namespace FAGui
         Engine::EngineMain& mEngine;
     };
 }
+

--- a/apps/freeablo/fagui/nkhelpers.h
+++ b/apps/freeablo/fagui/nkhelpers.h
@@ -1,4 +1,6 @@
+
 #pragma once
+
 #include "nuklearmisc/inputfwd.h"
 struct nk_vec2;
 struct nk_rect;
@@ -33,3 +35,4 @@ namespace FAGui
     // aligns inner_rect relatively to outer_rect using halign, valign as guides for positioning
     struct nk_rect alignRect(const struct nk_rect& inner_rect, const struct nk_rect& outer_rect, halign_t halign, valign_t valign);
 }
+

--- a/apps/freeablo/fagui/textcolor.h
+++ b/apps/freeablo/fagui/textcolor.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 namespace FAGui
@@ -10,3 +11,4 @@ namespace FAGui
         red,
     };
 }
+

--- a/apps/freeablo/falevelgen/levelgen.h
+++ b/apps/freeablo/falevelgen/levelgen.h
@@ -1,5 +1,5 @@
-#ifndef LEVELGEN_H
-#define LEVELGEN_H
+
+#pragma once
 
 #include "../faworld/gamelevel.h"
 
@@ -14,4 +14,3 @@ namespace FALevelGen
     FAWorld::GameLevel* generate(int32_t width, int32_t height, int32_t dLvl, const DiabloExe::DiabloExe& exe, int32_t previous, int32_t next);
 }
 
-#endif

--- a/apps/freeablo/falevelgen/mst.h
+++ b/apps/freeablo/falevelgen/mst.h
@@ -1,5 +1,5 @@
-#ifndef MST_H
-#define MST_H
+
+#pragma once
 
 #include <cstddef>
 #include <stdint.h>
@@ -10,4 +10,3 @@ namespace FALevelGen
     void minimumSpanningTree(const std::vector<std::vector<int32_t>>& graph, std::vector<int32_t>& parent);
 }
 
-#endif

--- a/apps/freeablo/falevelgen/random.h
+++ b/apps/freeablo/falevelgen/random.h
@@ -1,5 +1,6 @@
-#ifndef FA_RANDOM_H
-#define FA_RANDOM_H
+
+#pragma once
+
 #include <initializer_list>
 #include <vector>
 namespace FALevelGen
@@ -31,4 +32,3 @@ namespace FALevelGen
     };
 }
 
-#endif

--- a/apps/freeablo/falevelgen/tileset.h
+++ b/apps/freeablo/falevelgen/tileset.h
@@ -1,5 +1,5 @@
-#ifndef FA_TILESET_H
-#define FA_TILESET_H
+
+#pragma once
 
 #include <map>
 #include <settings/settings.h>
@@ -188,4 +188,3 @@ namespace FALevelGen
     };
 }
 
-#endif

--- a/apps/freeablo/farender/animationplayer.h
+++ b/apps/freeablo/farender/animationplayer.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include "../faworld/world.h"
@@ -52,3 +53,4 @@ namespace FARender
         std::vector<int32_t> mFrameSequence;
     };
 }
+

--- a/apps/freeablo/farender/fontinfo.h
+++ b/apps/freeablo/farender/fontinfo.h
@@ -1,4 +1,6 @@
+
 #pragma once
+
 #include "fa_nuklear.h"
 
 #include <array>
@@ -51,3 +53,4 @@ namespace FARender
         friend class Renderer;
     };
 }
+

--- a/apps/freeablo/farender/renderer.h
+++ b/apps/freeablo/farender/renderer.h
@@ -1,5 +1,5 @@
-#ifndef FA_RENDERER_H
-#define FA_RENDERER_H
+
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -150,4 +150,3 @@ namespace FARender
     };
 }
 
-#endif

--- a/apps/freeablo/farender/spritecache.h
+++ b/apps/freeablo/farender/spritecache.h
@@ -1,5 +1,5 @@
-#ifndef SPRITE_CACHE_H
-#define SPRITE_CACHE_H
+
+#pragma once
 
 #include <atomic>
 #include <list>
@@ -146,4 +146,3 @@ namespace FARender
     };
 }
 
-#endif

--- a/apps/freeablo/farender/spritemanager.h
+++ b/apps/freeablo/farender/spritemanager.h
@@ -1,5 +1,5 @@
-#ifndef SPRITE_MANAGER_H
-#define SPRITE_MANAGER_H
+
+#pragma once
 
 #include "spritecache.h"
 
@@ -79,4 +79,3 @@ namespace FARender
     };
 }
 
-#endif

--- a/apps/freeablo/fasavegame/gameloader.h
+++ b/apps/freeablo/fasavegame/gameloader.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <functional>
@@ -24,3 +25,4 @@ namespace FASaveGame
         GameSaver(Serial::WriteStreamInterface& stream) : Serial::Saver(stream) {}
     };
 }
+

--- a/apps/freeablo/fasavegame/objectidmapper.h
+++ b/apps/freeablo/fasavegame/objectidmapper.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <cstdint>
@@ -19,3 +20,4 @@ namespace FASaveGame
         std::unordered_map<std::string, std::function<void*(GameLoader&)>> mMappings;
     };
 }
+

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -1,4 +1,6 @@
+
 #pragma once
+
 #include "../farender/animationplayer.h"
 #include "actoranimationmanager.h"
 #include "actorstats.h"
@@ -103,3 +105,4 @@ namespace FAWorld
         std::string mNpcId;
     };
 }
+

--- a/apps/freeablo/faworld/actor/attackstate.h
+++ b/apps/freeablo/faworld/actor/attackstate.h
@@ -1,5 +1,5 @@
-#ifndef ACTOR_ATTACKSTATE_H
-#define ACTOR_ATTACKSTATE_H
+
+#pragma once
 
 #include <misc/misc.h>
 #include <statemachine/statemachine.h>
@@ -24,4 +24,3 @@ namespace FAWorld
     }
 }
 
-#endif

--- a/apps/freeablo/faworld/actor/basestate.h
+++ b/apps/freeablo/faworld/actor/basestate.h
@@ -1,5 +1,5 @@
-#ifndef ACTOR_BASESTATE_H
-#define ACTOR_BASESTATE_H
+
+#pragma once
 
 #include <boost/optional.hpp>
 #include <misc/misc.h>
@@ -23,4 +23,3 @@ namespace FAWorld
     }
 }
 
-#endif

--- a/apps/freeablo/faworld/actoranimationmanager.h
+++ b/apps/freeablo/faworld/actoranimationmanager.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <unordered_map>
@@ -66,3 +67,4 @@ namespace FAWorld
         int32_t mInterruptedAnimationFrame = 0;
     };
 }
+

--- a/apps/freeablo/faworld/actorstats.h
+++ b/apps/freeablo/faworld/actorstats.h
@@ -1,5 +1,5 @@
-#ifndef ACTORSTATS_H
-#define ACTORSTATS_H
+
+#pragma once
 
 #include <misc/maxcurrentitem.h>
 #include <stdint.h>
@@ -33,4 +33,3 @@ namespace FAWorld
     };
 }
 
-#endif // ACTORSTATS_H

--- a/apps/freeablo/faworld/behaviour.h
+++ b/apps/freeablo/faworld/behaviour.h
@@ -1,5 +1,5 @@
-#ifndef BEHAVIOUR_H
-#define BEHAVIOUR_H
+
+#pragma once
 
 #include <misc/misc.h>
 
@@ -69,4 +69,3 @@ namespace FAWorld
     };
 }
 
-#endif

--- a/apps/freeablo/faworld/faction.h
+++ b/apps/freeablo/faworld/faction.h
@@ -1,5 +1,5 @@
-#ifndef FACTION_H
-#define FACTION_H
+
+#pragma once
 
 #include <cstdint>
 
@@ -36,4 +36,3 @@ namespace FAWorld
     };
 }
 
-#endif

--- a/apps/freeablo/faworld/findpath.h
+++ b/apps/freeablo/faworld/findpath.h
@@ -1,5 +1,5 @@
-#ifndef COMPONENTS_LEVEL_PATHFINDING_H_
-#define COMPONENTS_LEVEL_PATHFINDING_H_
+
+#pragma once
 
 #include <algorithm>
 #include <functional>
@@ -21,4 +21,4 @@ namespace FAWorld
     std::vector<std::pair<int32_t, int32_t>>
     pathFind(GameLevelImpl* level, std::pair<int32_t, int32_t> start, std::pair<int32_t, int32_t>& goal, bool& bArrivable, bool findAdjacent);
 }
-#endif /* COMPONENTS_LEVEL_PATHFINDING_H_ */
+

--- a/apps/freeablo/faworld/gamelevel.h
+++ b/apps/freeablo/faworld/gamelevel.h
@@ -1,5 +1,5 @@
-#ifndef FAWORLD_LEVEL_H
-#define FAWORLD_LEVEL_H
+
+#pragma once
 
 #include <level/level.h>
 #include <unordered_map>
@@ -101,4 +101,3 @@ namespace FAWorld
     };
 }
 
-#endif

--- a/apps/freeablo/faworld/hoverstate.h
+++ b/apps/freeablo/faworld/hoverstate.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include "itemmap.h"
@@ -33,3 +34,4 @@ namespace FAWorld
         HoverState(HoverType typeArg) : mType(typeArg) {}
     };
 }
+

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -1,5 +1,5 @@
-#ifndef INVENTORY_H
-#define INVENTORY_H
+
+#pragma once
 
 #include "item.h"
 #include <diabloexe/diabloexe.h>
@@ -133,4 +133,3 @@ namespace FAWorld
     };
 }
 
-#endif // INVENTORY_H

--- a/apps/freeablo/faworld/item.h
+++ b/apps/freeablo/faworld/item.h
@@ -1,5 +1,6 @@
-#ifndef ITEM_H
-#define ITEM_H
+
+#pragma once
+
 #include <cel/celfile.h>
 #include <cel/celframe.h>
 #include <diabloexe/affix.h>
@@ -297,4 +298,4 @@ namespace FAWorld
         std::string mDropItemGraphicsPath;
     };
 }
-#endif // ITEM_H
+

--- a/apps/freeablo/faworld/itemmanager.h
+++ b/apps/freeablo/faworld/itemmanager.h
@@ -1,5 +1,5 @@
-#ifndef ITEMMANAGER_H
-#define ITEMMANAGER_H
+
+#pragma once
 
 #include <boost/program_options.hpp>
 #include <diabloexe/diabloexe.h>
@@ -61,4 +61,3 @@ namespace FAWorld
     };
 }
 
-#endif // ITEMMANAGER_H

--- a/apps/freeablo/faworld/itemmap.h
+++ b/apps/freeablo/faworld/itemmap.h
@@ -1,5 +1,5 @@
-#ifndef ITEM_MAP_H
-#define ITEM_MAP_H
+
+#pragma once
 
 #include <map>
 #include <memory>
@@ -99,4 +99,3 @@ namespace FAWorld
     };
 }
 
-#endif

--- a/apps/freeablo/faworld/movementhandler.h
+++ b/apps/freeablo/faworld/movementhandler.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include "gamelevel.h"
@@ -43,3 +44,4 @@ namespace FAWorld
         bool mAdjacent = false;
     };
 }
+

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -1,5 +1,6 @@
-#ifndef PLAYER_H
-#define PLAYER_H
+
+#pragma once
+
 #include "actor.h"
 #include "inventory.h"
 #include <boost/format.hpp>
@@ -44,4 +45,4 @@ namespace FAWorld
         boost::signals2::signal<void(Actor*)> talkRequested;
     };
 }
-#endif
+

--- a/apps/freeablo/faworld/playerfactory.h
+++ b/apps/freeablo/faworld/playerfactory.h
@@ -1,5 +1,5 @@
-#ifndef PLAYERFACTORY_H
-#define PLAYERFACTORY_H
+
+#pragma once
 
 #include "../components/diabloexe/diabloexe.h"
 #include <string>
@@ -27,4 +27,3 @@ namespace FAWorld
     };
 }
 
-#endif

--- a/apps/freeablo/faworld/position.h
+++ b/apps/freeablo/faworld/position.h
@@ -1,5 +1,5 @@
-#ifndef POSITION_H
-#define POSITION_H
+
+#pragma once
 
 #include <cmath>
 #include <misc/misc.h>
@@ -47,4 +47,3 @@ namespace FAWorld
     };
 }
 
-#endif

--- a/apps/freeablo/faworld/world.h
+++ b/apps/freeablo/faworld/world.h
@@ -1,5 +1,5 @@
-#ifndef WORLD_H
-#define WORLD_H
+
+#pragma once
 
 #include <map>
 #include <memory>
@@ -130,4 +130,3 @@ namespace FAWorld
     };
 }
 
-#endif

--- a/components/audio/audio.h
+++ b/components/audio/audio.h
@@ -1,5 +1,5 @@
-#ifndef AUDIO_H
-#define AUDIO_H
+
+#pragma once
 
 #include <string>
 
@@ -25,4 +25,3 @@ namespace Audio
     bool channelPlaying(int32_t channel);
 }
 
-#endif

--- a/components/cel/celdecoder.h
+++ b/components/cel/celdecoder.h
@@ -1,5 +1,5 @@
-#ifndef CEL_DECODING_H
-#define CEL_DECODING_H
+
+#pragma once
 
 #include "celframe.h"
 #include "pal.h"
@@ -72,4 +72,3 @@ namespace Cel
     };
 }
 
-#endif

--- a/components/cel/celfile.h
+++ b/components/cel/celfile.h
@@ -1,5 +1,5 @@
-#ifndef CEL_FILE_H
-#define CEL_FILE_H
+
+#pragma once
 
 #include "celdecoder.h"
 #include "celframe.h"
@@ -27,4 +27,3 @@ namespace Cel
     };
 }
 
-#endif

--- a/components/cel/celframe.h
+++ b/components/cel/celframe.h
@@ -1,5 +1,5 @@
-#ifndef CEL_FRAME_H
-#define CEL_FRAME_H
+
+#pragma once
 
 #include <misc/helper2d.h>
 #include <stdint.h>
@@ -27,4 +27,3 @@ namespace Cel
     };
 }
 
-#endif

--- a/components/cel/pal.h
+++ b/components/cel/pal.h
@@ -1,5 +1,5 @@
-#ifndef PAL_H
-#define PAL_H
+
+#pragma once
 
 #include <stdint.h>
 #include <string>
@@ -37,4 +37,3 @@ namespace Cel
     };
 }
 
-#endif

--- a/components/diabloexe/affix.h
+++ b/components/diabloexe/affix.h
@@ -1,5 +1,6 @@
-#ifndef PREFIX_H
-#define PREFIX_H
+
+#pragma once
+
 #include <stdint.h>
 
 #include <faio/fafileobject.h>
@@ -38,4 +39,3 @@ namespace DiabloExe
     };
 }
 
-#endif // PREFIX_H

--- a/components/diabloexe/baseitem.h
+++ b/components/diabloexe/baseitem.h
@@ -1,5 +1,6 @@
-#ifndef BASEITEM_H
-#define BASEITEM_H
+
+#pragma once
+
 #include <stdint.h>
 
 #include <faio/fafileobject.h>
@@ -56,4 +57,3 @@ namespace DiabloExe
     };
 }
 
-#endif // BASEITEM_H

--- a/components/diabloexe/characterstats.h
+++ b/components/diabloexe/characterstats.h
@@ -1,5 +1,6 @@
-#ifndef CHARACTERSTATS_H
-#define CHARACTERSTATS_H
+
+#pragma once
+
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -36,4 +37,4 @@ namespace DiabloExe
         std::vector<uint32_t> mNextLevelExp;
     };
 }
-#endif // CHARACTERSTATS_H
+

--- a/components/diabloexe/diabloexe.h
+++ b/components/diabloexe/diabloexe.h
@@ -1,5 +1,5 @@
-#ifndef DIABLO_EXE_H
-#define DIABLO_EXE_H
+
+#pragma once
 
 #include <array>
 #include <map>
@@ -92,4 +92,3 @@ namespace DiabloExe
     };
 }
 
-#endif

--- a/components/diabloexe/monster.h
+++ b/components/diabloexe/monster.h
@@ -1,5 +1,5 @@
-#ifndef MONSTER_H
-#define MONSTER_H
+
+#pragma once
 
 #include <stdint.h>
 
@@ -99,4 +99,3 @@ namespace DiabloExe
     };
 }
 
-#endif

--- a/components/diabloexe/npc.h
+++ b/components/diabloexe/npc.h
@@ -1,5 +1,5 @@
-#ifndef EXE_NPC_H
-#define EXE_NPC_H
+
+#pragma once
 
 #include <boost/optional/optional.hpp>
 #include <faio/fafileobject.h>
@@ -31,4 +31,3 @@ namespace DiabloExe
     };
 }
 
-#endif

--- a/components/diabloexe/uniqueitem.h
+++ b/components/diabloexe/uniqueitem.h
@@ -1,5 +1,6 @@
-#ifndef UNIQUEITEM_H
-#define UNIQUEITEM_H
+
+#pragma once
+
 #include <faio/fafileobject.h>
 #include <stdint.h>
 #include <string>
@@ -52,4 +53,4 @@ namespace DiabloExe
         friend class DiabloExe;
     };
 }
-#endif // UNIQUEITEM_H
+

--- a/components/faio/fafileobject.h
+++ b/components/faio/fafileobject.h
@@ -1,7 +1,6 @@
 /// this is just a RAII wrapper class for faio api functions.
 
-#ifndef FAFILEWRAPPER_H
-#define FAFILEWRAPPER_H
+#pragma once
 
 #include "faio.h"
 
@@ -39,4 +38,3 @@ namespace FAIO
     };
 }
 
-#endif

--- a/components/faio/faio.h
+++ b/components/faio/faio.h
@@ -1,5 +1,5 @@
-#ifndef FAIO_H
-#define FAIO_H
+
+#pragma once
 
 #include <stdint.h>
 #include <stdio.h>
@@ -64,4 +64,3 @@ namespace FAIO
     std::string getMPQFileName();
 }
 
-#endif

--- a/components/input/common.h
+++ b/components/input/common.h
@@ -1,5 +1,5 @@
-#ifndef COMMON_H
-#define COMMON_H
+
+#pragma once
 
 #include "hotkey.h"
 #include "keys.h"
@@ -31,4 +31,3 @@ namespace Input
     int convertAsciiToRocketKey(int asciik);
 }
 
-#endif /* COMMON_H */

--- a/components/input/hotkey.h
+++ b/components/input/hotkey.h
@@ -1,5 +1,5 @@
-#ifndef HOTKEY_H
-#define HOTKEY_H
+
+#pragma once
 
 #include <string>
 
@@ -21,4 +21,3 @@ namespace Input
     };
 }
 
-#endif /* HOTKEY_H */

--- a/components/input/inputmanager.h
+++ b/components/input/inputmanager.h
@@ -1,5 +1,5 @@
-#ifndef INPUT_H
-#define INPUT_H
+
+#pragma once
 
 #include <functional>
 #include <stdint.h>
@@ -92,4 +92,3 @@ namespace Input
     };
 }
 
-#endif

--- a/components/input/keys.h
+++ b/components/input/keys.h
@@ -1,5 +1,5 @@
-#ifndef KEYS_H
-#define KEYS_H
+
+#pragma once
 
 namespace Input
 {
@@ -151,4 +151,3 @@ namespace Input
     };
 }
 
-#endif

--- a/components/level/baseitemmanager.h
+++ b/components/level/baseitemmanager.h
@@ -1,5 +1,6 @@
-#ifndef BASEITEMMANAGER_H
-#define BASEITEMMANAGER_H
+
+#pragma once
+
 #include <map>
 #include <stdint.h>
 
@@ -11,4 +12,3 @@ namespace Level
     };
 }
 
-#endif // BASEITEMMANAGER_H

--- a/components/level/baseproperty.h
+++ b/components/level/baseproperty.h
@@ -1,5 +1,6 @@
-#ifndef ITEM_H
-#define ITEM_H
+
+#pragma once
+
 namespace FAWorld
 {
     class Inventory;
@@ -21,4 +22,4 @@ namespace Level
         property_type mProperty;
     };
 }
-#endif // ITEM_H
+

--- a/components/level/dun.h
+++ b/components/level/dun.h
@@ -1,5 +1,5 @@
-#ifndef DUN_FILE_H
-#define DUN_FILE_H
+
+#pragma once
 
 #include <stdint.h>
 #include <string>
@@ -47,4 +47,3 @@ namespace Level
     };
 }
 
-#endif

--- a/components/level/level.h
+++ b/components/level/level.h
@@ -1,5 +1,5 @@
-#ifndef LEVEL_H
-#define LEVEL_H
+
+#pragma once
 
 #include "baseitemmanager.h"
 #include "dun.h"
@@ -105,4 +105,3 @@ namespace Level
     };
 }
 
-#endif

--- a/components/level/min.h
+++ b/components/level/min.h
@@ -1,5 +1,5 @@
-#ifndef MIN_H
-#define MIN_H
+
+#pragma once
 
 #include <stdint.h>
 #include <string>
@@ -21,4 +21,3 @@ namespace Level
     };
 }
 
-#endif

--- a/components/level/sol.h
+++ b/components/level/sol.h
@@ -1,5 +1,5 @@
-#ifndef SOL_H
-#define SOL_H
+
+#pragma once
 
 #include <string>
 #include <vector>
@@ -23,4 +23,3 @@ namespace Level
     };
 }
 
-#endif

--- a/components/level/tileset.h
+++ b/components/level/tileset.h
@@ -1,5 +1,5 @@
-#ifndef TIL_H
-#define TIL_H
+
+#pragma once
 
 #include <stdint.h>
 #include <string>
@@ -23,4 +23,3 @@ namespace Level
     };
 }
 
-#endif

--- a/components/misc/assert.h
+++ b/components/misc/assert.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <stdio.h>
@@ -22,3 +23,4 @@
 #else
 #define debug_assert(cond) release_assert(cond)
 #endif
+

--- a/components/misc/disablewarn.h
+++ b/components/misc/disablewarn.h
@@ -15,3 +15,4 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
+

--- a/components/misc/helper2d.h
+++ b/components/misc/helper2d.h
@@ -1,5 +1,5 @@
-#ifndef HELPER_2D_H
-#define HELPER_2D_H
+
+#pragma once
 
 #include <cstdint>
 
@@ -23,4 +23,3 @@ namespace Misc
     };
 }
 
-#endif

--- a/components/misc/maxcurrentitem.h
+++ b/components/misc/maxcurrentitem.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 namespace Serial
@@ -22,3 +23,4 @@ namespace Misc
         void reclamp(); ///< make sure the value is clamped into its range
     };
 }
+

--- a/components/misc/md5.h
+++ b/components/misc/md5.h
@@ -41,8 +41,7 @@
   1999-05-03 lpd Original version.
  */
 
-#ifndef md5_INCLUDED
-#define md5_INCLUDED
+#pragma once
 
 namespace Misc
 {
@@ -95,4 +94,4 @@ namespace Misc
     //}  /* end extern "C" */
     //#endif
 }
-#endif /* md5_INCLUDED */
+

--- a/components/misc/misc.h
+++ b/components/misc/misc.h
@@ -1,5 +1,5 @@
-#ifndef FA_MISC_H
-#define FA_MISC_H
+
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -109,4 +109,3 @@ namespace Misc
 
 #define UNUSED_PARAM(x) (void)(x)
 
-#endif

--- a/components/misc/savePNG.h
+++ b/components/misc/savePNG.h
@@ -1,5 +1,6 @@
-#ifndef _SDL_SAVEPNG
-#define _SDL_SAVEPNG
+
+#pragma once
+
 /*
  * SDL_SavePNG -- libpng-based SDL_Surface writer.
  *
@@ -32,4 +33,3 @@ extern int SDL_SavePNG_RW(SDL_Surface* surface, SDL_RWops* rw, int freedst);
  */
 extern SDL_Surface* SDL_PNGFormatAlpha(SDL_Surface* src);
 
-#endif

--- a/components/misc/stdhashes.h
+++ b/components/misc/stdhashes.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 // hash functions for types that are missing them, so they can be sued as keys in std::unordered_map
@@ -21,3 +22,4 @@ struct EnumClassHash
 {
     template <typename T> std::size_t operator()(T t) const { return static_cast<std::size_t>(t); }
 };
+

--- a/components/misc/stringops.h
+++ b/components/misc/stringops.h
@@ -1,8 +1,7 @@
 // Taken from OpenMW: https://github.com/zinnschlag/openmw/blob/6fd4cdb5fb94db503b5d3bf7ddc30160397862ec/components/misc/stringops.hpp
 // License: GPLv3 https://github.com/zinnschlag/openmw/blob/6fd4cdb5fb94db503b5d3bf7ddc30160397862ec/GPL3.txt
 
-#ifndef MISC_STRINGOPS_H
-#define MISC_STRINGOPS_H
+#pragma once
 
 #include <algorithm>
 #include <cctype>
@@ -149,4 +148,4 @@ namespace Misc
         }
     };
 }
-#endif
+

--- a/components/nuklearmisc/inputfwd.h
+++ b/components/nuklearmisc/inputfwd.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <fa_nuklear.h>
@@ -12,3 +13,4 @@ namespace NuklearMisc
     void handleNuklearKeyboardEvent(nk_context* ctx, bool isDown, Input::Key sym, Input::KeyboardModifiers mods);
     void handleNuklearTextInputEvent(nk_context* ctx, const std::string& inp);
 }
+

--- a/components/nuklearmisc/standaloneguispritehandler.h
+++ b/components/nuklearmisc/standaloneguispritehandler.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <fa_nuklear.h>
@@ -64,3 +65,4 @@ namespace NuklearMisc
         friend class GuiSprite;
     };
 }
+

--- a/components/nuklearmisc/widgets.h
+++ b/components/nuklearmisc/widgets.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <fa_nuklear.h>
@@ -7,3 +8,4 @@ namespace NuklearMisc
 {
     bool nk_file_pick(nk_context* ctx, const std::string& label, std::string& path, const std::string& filter, float rowHeight, float labelWidth = 120);
 }
+

--- a/components/render/levelobjects.h
+++ b/components/render/levelobjects.h
@@ -1,5 +1,5 @@
-#ifndef LEVEL_OBJ_H
-#define LEVEL_OBJ_H
+
+#pragma once
 
 #include "render.h"
 
@@ -45,4 +45,3 @@ namespace Render
     };
 }
 
-#endif

--- a/components/render/misc.h
+++ b/components/render/misc.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <string>
@@ -37,3 +38,4 @@ namespace Render
         virtual void setImmortal(uint32_t index, bool immortal) = 0;
     };
 }
+

--- a/components/render/nuklear_sdl_gl3.h
+++ b/components/render/nuklear_sdl_gl3.h
@@ -1,6 +1,5 @@
 
-#ifndef NK_SDL_GL3_H_
-#define NK_SDL_GL3_H_
+#pragma once
 
 #include <vector>
 
@@ -66,4 +65,3 @@ void nk_sdl_render_dump(Render::SpriteCacheBase* cache, NuklearFrameDump& dump, 
 void nk_sdl_device_destroy(nk_gl_device& dev);
 void nk_sdl_device_create(nk_gl_device& dev);
 
-#endif

--- a/components/render/render.h
+++ b/components/render/render.h
@@ -1,5 +1,5 @@
-#ifndef RENDER_H
-#define RENDER_H
+
+#pragma once
 
 #include <stdint.h>
 
@@ -139,4 +139,3 @@ namespace Render
     void clear(int r = 0, int g = 0, int b = 255);
 }
 
-#endif

--- a/components/render/rocketglue/RenderInterfaceSDL2.h
+++ b/components/render/rocketglue/RenderInterfaceSDL2.h
@@ -24,8 +24,8 @@
  * THE SOFTWARE.
  *
  */
-#ifndef RENDERINTERFACESDL2_H
-#define RENDERINTERFACESDL2_H
+
+#pragma once
 
 #include <Rocket/Core/RenderInterface.h>
 #include <misc/disablewarn.h>
@@ -113,4 +113,3 @@ private:
     }
 };
 
-#endif

--- a/components/render/rocketglue/SystemInterfaceSDL2.h
+++ b/components/render/rocketglue/SystemInterfaceSDL2.h
@@ -24,8 +24,8 @@
  * THE SOFTWARE.
  *
  */
-#ifndef SYSTEMINTEFACESDL2_H
-#define SYSTEMINTEFACESDL2_H
+
+#pragma once
 
 #include <Rocket/Core/Input.h>
 #include <Rocket/Core/SystemInterface.h>
@@ -38,4 +38,4 @@ public:
     float GetElapsedTime();
     bool LogMessage(Rocket::Core::Log::Type type, const Rocket::Core::String& message);
 };
-#endif
+

--- a/components/render/rocketglue/drawcommand.h
+++ b/components/render/rocketglue/drawcommand.h
@@ -1,5 +1,5 @@
-#ifndef DRAW_COMMAND_H
-#define DRAW_COMMAND_H
+
+#pragma once
 
 #include <Rocket/Core.h>
 #include <misc/disablewarn.h>
@@ -35,4 +35,3 @@ struct DrawCommand
     bool enableScissor;
 };
 
-#endif

--- a/components/render/sdl_gl_funcs.h
+++ b/components/render/sdl_gl_funcs.h
@@ -49,3 +49,4 @@ extern PFNGLACTIVETEXTUREPROC glActiveTexture;
 void initGlFuncs();
 
 #endif
+

--- a/components/serial/loader.h
+++ b/components/serial/loader.h
@@ -1,4 +1,6 @@
+
 #pragma once
+
 #include <cstdint>
 #include <string>
 
@@ -68,3 +70,4 @@ namespace Serial
 
     using ScopedCategorySaver = ScopedCategory<Saver>;
 }
+

--- a/components/serial/streaminterface.h
+++ b/components/serial/streaminterface.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <cstdint>
@@ -45,3 +46,4 @@ namespace Serial
         virtual void endCategory(const std::string& name) { UNUSED_PARAM(name); }
     };
 }
+

--- a/components/serial/textstream.h
+++ b/components/serial/textstream.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include "streaminterface.h"
@@ -59,3 +60,4 @@ namespace Serial
         std::string mTmp;
     };
 }
+

--- a/components/settings/settings.h
+++ b/components/settings/settings.h
@@ -1,5 +1,5 @@
-#ifndef SETTINGS_H
-#define SETTINGS_H
+
+#pragma once
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -129,4 +129,3 @@ namespace Settings
     };
 }
 
-#endif // SETTINGS_H

--- a/components/statemachine/statemachine.h
+++ b/components/statemachine/statemachine.h
@@ -1,5 +1,5 @@
-#ifndef STATEMACHINE_H
-#define STATEMACHINE_H
+
+#pragma once
 
 #include <boost/optional.hpp>
 #include <misc/misc.h>
@@ -74,4 +74,3 @@ namespace StateMachine
     };
 }
 
-#endif

--- a/extern/nativefiledialog/src/simple_exec.h
+++ b/extern/nativefiledialog/src/simple_exec.h
@@ -1,5 +1,4 @@
 // copied from: https://github.com/wheybags/simple_exec/blob/5a74c507c4ce1b2bb166177ead4cca7cfa23cb35/simple_exec.h
-// modified #ifndef SIMPLE_EXEC_H header guard to #pragma once
 
 // simple_exec.h, single header library to run external programs + retrieve their status code and output (unix only for now)
 //

--- a/extern/nativefiledialog/src/simple_exec.h
+++ b/extern/nativefiledialog/src/simple_exec.h
@@ -1,4 +1,5 @@
 // copied from: https://github.com/wheybags/simple_exec/blob/5a74c507c4ce1b2bb166177ead4cca7cfa23cb35/simple_exec.h
+// modified #ifndef SIMPLE_EXEC_H header guard to #pragma once
 
 // simple_exec.h, single header library to run external programs + retrieve their status code and output (unix only for now)
 //


### PR DESCRIPTION
Check if compiles successfully before using, just in case I overwritten something that depended on a `#define` Just simple spacing fixes so things aren't crowded together with everything .h converted to `#pragma`. I didn't touch anything from `freeablo/extern` see #325 