### PR TITLE
Fix interaction between pause menu and inventory panel. (#338)

### DIFF
--- a/apps/freeablo/engine/enginemain.cpp
+++ b/apps/freeablo/engine/enginemain.cpp
@@ -232,6 +232,8 @@ namespace Engine
 
     const DiabloExe::DiabloExe& EngineMain::exe() const { return *mExe; }
 
+    bool EngineMain::isPaused() const { return mPaused; }
+
     void EngineMain::stop() { mDone = true; }
 
     void EngineMain::togglePause() { mPaused = !mPaused; }

--- a/apps/freeablo/engine/enginemain.h
+++ b/apps/freeablo/engine/enginemain.h
@@ -38,6 +38,7 @@ namespace Engine
         // TODO: replace with enums
         void startGame(const std::string& characterClass);
         const DiabloExe::DiabloExe& exe() const;
+        bool isPaused() const;
 
     private:
         void runGameLoop(const boost::program_options::variables_map& variables, const std::string& pathEXE);

--- a/apps/freeablo/fagui/guimanager.h
+++ b/apps/freeablo/fagui/guimanager.h
@@ -104,6 +104,7 @@ namespace FAGui
         // current support for modal dialogs seem to be non-existant, so here'll be some workarounds:
         bool isModalDlgShown() const;
         void setPlayer(FAWorld::Player* player);
+        bool isLastWidgetHovered(nk_context* ctx) const;
 
     private:
         void nk_fa_begin_window(nk_context* ctx, const char* title, struct nk_rect bounds, nk_flags flags, std::function<void()> action, bool isModal);


### PR DESCRIPTION
Should fix #338
Also disables hover on items during pause. Note that if something is hovered before pressing pause description message and highlight should stay until pause is finished, that's true to original game.