### PR TITLE
Buying basic items + some player stats display

### DIFF
--- a/apps/freeablo/CMakeLists.txt
+++ b/apps/freeablo/CMakeLists.txt
@@ -68,6 +68,8 @@ add_library(freeablo_lib # split into a library so I can link to it from tests
     faworld/actoranimationmanager.cpp
     faworld/playerbehaviour.cpp
     faworld/playerbehaviour.h
+		faworld/playerstats.cpp
+    faworld/playerstats.h
     faworld/target.cpp
     faworld/target.h
     faworld/playerinput.h

--- a/apps/freeablo/CMakeLists.txt
+++ b/apps/freeablo/CMakeLists.txt
@@ -68,12 +68,14 @@ add_library(freeablo_lib # split into a library so I can link to it from tests
     faworld/actoranimationmanager.cpp
     faworld/playerbehaviour.cpp
     faworld/playerbehaviour.h
-		faworld/playerstats.cpp
+    faworld/playerstats.cpp
     faworld/playerstats.h
     faworld/target.cpp
     faworld/target.h
     faworld/playerinput.h
     faworld/playerinput.cpp
+    faworld/storedata.h
+    faworld/storedata.cpp
 
     fagui/textcolor.h
     fagui/guimanager.h

--- a/apps/freeablo/engine/localinputhandler.cpp
+++ b/apps/freeablo/engine/localinputhandler.cpp
@@ -44,6 +44,8 @@ namespace Engine
             return;
 
         auto player = mWorld.getCurrentPlayer();
+        if (!player)
+            return;
         switch (action)
         {
             case Engine::MouseInputAction::MOUSE_DOWN:

--- a/apps/freeablo/fagui/dialogmanager.cpp~RFae6fefe.TMP
+++ b/apps/freeablo/fagui/dialogmanager.cpp~RFae6fefe.TMP
@@ -399,7 +399,7 @@ namespace FAGui
             auto price = item.getPrice();
             auto header = d.getHeader();
             d.textLines(item.descriptionForMerchants(), TextColor::white, false, {20, 40, 40})
-                .setAction([this, price, header, it, &items]() mutable {
+                .setAction([ this, price, header, it, &items ]() mutable {
                     if (mWorld.getCurrentPlayer()->getTotalGold() < price)
                         return fillMessageDialog(header, "You do not have enough gold");
 

--- a/apps/freeablo/fagui/dialogmanager.h
+++ b/apps/freeablo/fagui/dialogmanager.h
@@ -68,7 +68,7 @@ namespace FAGui
         void separator();
         DialogLineData& footer(const std::string& text);
         void header(const std::vector<std::string>& text);
-        void header(std::vector<DialogLineData> data) { mHeader = std::move (data);}
+        void header(std::vector<DialogLineData> data) { mHeader = std::move(data); }
         int32_t selectedLine();
         void notify(Engine::KeyboardInputAction action, GuiManager& manager);
         void widen() { mIsWide = true; }
@@ -78,7 +78,7 @@ namespace FAGui
         bool isVisible(int32_t line) const { return line >= mFirstVisible && line < mFirstVisible + visibleBodyLineCount(); }
         double selectedLinePercent();
         void clearLines();
-        std::vector<DialogLineData> getHeader () const { return mHeader; }
+        std::vector<DialogLineData> getHeader() const { return mHeader; }
 
     private:
         std::vector<DialogLineData> mHeader;
@@ -100,7 +100,7 @@ namespace FAGui
 
     private:
         template <typename FilterType> void sellDialog(FilterType filter);
-        void buyDialog (std::vector<FAWorld::Item> &items);
+        void buyDialog(std::vector<FAWorld::Item>& items);
 
         void talkOgden(const FAWorld::Actor* npc);
         void talkFarnham(const FAWorld::Actor* npc);

--- a/apps/freeablo/fagui/dialogmanager.h
+++ b/apps/freeablo/fagui/dialogmanager.h
@@ -68,6 +68,7 @@ namespace FAGui
         void separator();
         DialogLineData& footer(const std::string& text);
         void header(const std::vector<std::string>& text);
+        void header(std::vector<DialogLineData> data) { mHeader = std::move (data);}
         int32_t selectedLine();
         void notify(Engine::KeyboardInputAction action, GuiManager& manager);
         void widen() { mIsWide = true; }
@@ -77,6 +78,7 @@ namespace FAGui
         bool isVisible(int32_t line) const { return line >= mFirstVisible && line < mFirstVisible + visibleBodyLineCount(); }
         double selectedLinePercent();
         void clearLines();
+        std::vector<DialogLineData> getHeader () const { return mHeader; }
 
     private:
         std::vector<DialogLineData> mHeader;
@@ -94,9 +96,11 @@ namespace FAGui
     public:
         explicit DialogManager(GuiManager& gui_manager, FAWorld::World& world);
         void talk(const FAWorld::Actor* npc);
+        void fillMessageDialog(std::vector<DialogLineData> header, const char* text);
 
     private:
         template <typename FilterType> void sellDialog(FilterType filter);
+        void buyDialog (std::vector<FAWorld::Item> &items);
 
         void talkOgden(const FAWorld::Actor* npc);
         void talkFarnham(const FAWorld::Actor* npc);
@@ -108,7 +112,7 @@ namespace FAGui
         void talkGriswold(const FAWorld::Actor* npc);
         void quitDialog() const;
 
-        void fillConfirmDialog(DialogData& data, const FAWorld::Item& item, int price, const char* question, std::function<void()> successAction);
+        void confirmDialog(std::vector<DialogLineData> header, const FAWorld::Item& item, int price, const char* question, std::function<void()> successAction);
 
     private:
         GuiManager& mGuiManager;

--- a/apps/freeablo/fagui/guimanager.cpp
+++ b/apps/freeablo/fagui/guimanager.cpp
@@ -141,6 +141,17 @@ namespace FAGui
 
     void GuiManager::dialog(nk_context* ctx)
     {
+        // This part is needed because dialog is triggered by mouse click
+        // and if nuklear gui will appear on the same frame as click happens -
+        // nuklear will treat dialog-triggering click as click on its window
+        // thus incorrectly triggering dialog action if your cursor is on it.
+        // This workaround seems to fully mitigate it.
+        if (mSkipDialogFrame)
+        {
+            mSkipDialogFrame = false;
+            return;
+        }
+
         if (mDialogs.empty())
             return;
 
@@ -513,7 +524,7 @@ namespace FAGui
                 smallText(ctx, text, color);
             };
             fillTextField(168, 21, 131, toString(mPlayer->getClass()));
-            auto &playerStats = mPlayer->getPlayerStats();
+            auto& playerStats = mPlayer->getPlayerStats();
             fillTextField(95, 144, 31, std::to_string(playerStats.mStrength).c_str());
             fillTextField(95, 172, 31, std::to_string(playerStats.mMagic).c_str());
             fillTextField(95, 200, 31, std::to_string(playerStats.mDexterity).c_str());
@@ -913,7 +924,11 @@ namespace FAGui
 
     void GuiManager::popDialogData() { mDialogs.pop_back(); }
 
-    void GuiManager::pushDialogData(DialogData&& data) { mDialogs.push_back(std::move(data)); }
+    void GuiManager::pushDialogData(DialogData&& data)
+    {
+        mDialogs.push_back(std::move(data));
+        mSkipDialogFrame = true;
+    }
 
     bool GuiManager::isPauseBlocked() const
     {

--- a/apps/freeablo/fagui/guimanager.cpp
+++ b/apps/freeablo/fagui/guimanager.cpp
@@ -513,10 +513,18 @@ namespace FAGui
                 smallText(ctx, text, color);
             };
             fillTextField(168, 21, 131, toString(mPlayer->getClass()));
-            fillTextField(95, 144, 31, std::to_string(mPlayer->getPlayerStats().mStrength).c_str());
-            fillTextField(95, 172, 31, std::to_string(mPlayer->getPlayerStats().mMagic).c_str());
-            fillTextField(95, 200, 31, std::to_string(mPlayer->getPlayerStats().mDexterity).c_str());
-            fillTextField(95, 228, 31, std::to_string(mPlayer->getPlayerStats().mVitality).c_str());
+            auto &playerStats = mPlayer->getPlayerStats();
+            fillTextField(95, 144, 31, std::to_string(playerStats.mStrength).c_str());
+            fillTextField(95, 172, 31, std::to_string(playerStats.mMagic).c_str());
+            fillTextField(95, 200, 31, std::to_string(playerStats.mDexterity).c_str());
+            fillTextField(95, 228, 31, std::to_string(playerStats.mVitality).c_str());
+
+            fillTextField(216, 135, 84, std::to_string(mPlayer->getTotalGold()).c_str());
+            auto& stats = mPlayer->getStats();
+            fillTextField(95, 293, 31, std::to_string(stats.mHp.max).c_str());
+            fillTextField(143, 293, 31, std::to_string(stats.mHp.current).c_str(), stats.mHp.current < stats.mHp.max ? TextColor::red : TextColor::white);
+            fillTextField(95, 321, 31, std::to_string(stats.mMana.max).c_str());
+            fillTextField(143, 321, 31, std::to_string(stats.mMana.current).c_str(), stats.mMana.current < stats.mMana.max ? TextColor::red : TextColor::white);
 
             nk_layout_space_end(ctx);
         });

--- a/apps/freeablo/fagui/guimanager.cpp
+++ b/apps/freeablo/fagui/guimanager.cpp
@@ -513,29 +513,31 @@ namespace FAGui
         });
     }
 
+    void GuiManager::fillTextField(nk_context* ctx, float x, float y, float width, const char* text, TextColor color)
+    {
+        nk_layout_space_push(ctx, nk_rect(x, y, width, FARender::Renderer::get()->smallFont()->height));
+        smallText(ctx, text, color);
+    }
+
     void GuiManager::characterPanel(nk_context* ctx)
     {
         drawPanel(ctx, PanelType::character, [&]() {
             nk_layout_space_begin(ctx, NK_STATIC, 0, INT_MAX);
 
-            auto renderer = FARender::Renderer::get();
-            auto fillTextField = [&](float x, float y, float width, const char* text, TextColor color = TextColor::white) {
-                nk_layout_space_push(ctx, nk_rect(x, y, width, renderer->smallFont()->height));
-                smallText(ctx, text, color);
-            };
-            fillTextField(168, 21, 131, toString(mPlayer->getClass()));
+            fillTextField(ctx, 168, 21, 131, toString(mPlayer->getClass()));
             auto& playerStats = mPlayer->getPlayerStats();
-            fillTextField(95, 144, 31, std::to_string(playerStats.mStrength).c_str());
-            fillTextField(95, 172, 31, std::to_string(playerStats.mMagic).c_str());
-            fillTextField(95, 200, 31, std::to_string(playerStats.mDexterity).c_str());
-            fillTextField(95, 228, 31, std::to_string(playerStats.mVitality).c_str());
+            fillTextField(ctx, 95, 144, 31, std::to_string(playerStats.mStrength).c_str());
+            fillTextField(ctx, 95, 172, 31, std::to_string(playerStats.mMagic).c_str());
+            fillTextField(ctx, 95, 200, 31, std::to_string(playerStats.mDexterity).c_str());
+            fillTextField(ctx, 95, 228, 31, std::to_string(playerStats.mVitality).c_str());
 
-            fillTextField(216, 135, 84, std::to_string(mPlayer->getTotalGold()).c_str());
+            fillTextField(ctx, 216, 135, 84, std::to_string(mPlayer->getTotalGold()).c_str());
             auto& stats = mPlayer->getStats();
-            fillTextField(95, 293, 31, std::to_string(stats.mHp.max).c_str());
-            fillTextField(143, 293, 31, std::to_string(stats.mHp.current).c_str(), stats.mHp.current < stats.mHp.max ? TextColor::red : TextColor::white);
-            fillTextField(95, 321, 31, std::to_string(stats.mMana.max).c_str());
-            fillTextField(143, 321, 31, std::to_string(stats.mMana.current).c_str(), stats.mMana.current < stats.mMana.max ? TextColor::red : TextColor::white);
+            fillTextField(ctx, 95, 293, 31, std::to_string(stats.mHp.max).c_str());
+            fillTextField(ctx, 143, 293, 31, std::to_string(stats.mHp.current).c_str(), stats.mHp.current < stats.mHp.max ? TextColor::red : TextColor::white);
+            fillTextField(ctx, 95, 321, 31, std::to_string(stats.mMana.max).c_str());
+            fillTextField(
+                ctx, 143, 321, 31, std::to_string(stats.mMana.current).c_str(), stats.mMana.current < stats.mMana.max ? TextColor::red : TextColor::white);
 
             nk_layout_space_end(ctx);
         });

--- a/apps/freeablo/fagui/guimanager.cpp
+++ b/apps/freeablo/fagui/guimanager.cpp
@@ -504,7 +504,22 @@ namespace FAGui
 
     void GuiManager::characterPanel(nk_context* ctx)
     {
-        drawPanel(ctx, PanelType::character, [&]() {});
+        drawPanel(ctx, PanelType::character, [&]() {
+            nk_layout_space_begin(ctx, NK_STATIC, 0, INT_MAX);
+
+            auto renderer = FARender::Renderer::get();
+            auto fillTextField = [&](float x, float y, float width, const char* text, TextColor color = TextColor::white) {
+                nk_layout_space_push(ctx, nk_rect(x, y, width, renderer->smallFont()->height));
+                smallText(ctx, text, color);
+            };
+            fillTextField(168, 21, 131, toString(mPlayer->getClass()));
+            fillTextField(95, 144, 31, std::to_string(mPlayer->getPlayerStats().mStrength).c_str());
+            fillTextField(95, 172, 31, std::to_string(mPlayer->getPlayerStats().mMagic).c_str());
+            fillTextField(95, 200, 31, std::to_string(mPlayer->getPlayerStats().mDexterity).c_str());
+            fillTextField(95, 228, 31, std::to_string(mPlayer->getPlayerStats().mVitality).c_str());
+
+            nk_layout_space_end(ctx);
+        });
     }
 
     void GuiManager::questsPanel(nk_context* ctx)

--- a/apps/freeablo/fagui/guimanager.h
+++ b/apps/freeablo/fagui/guimanager.h
@@ -149,5 +149,6 @@ namespace FAGui
         std::unique_ptr<MenuHandler> mMenuHandler;
         FAWorld::Item* mGoldSplitTarget = nullptr;
         int mGoldSplitCnt = 0;
+        bool mSkipDialogFrame = false;
     };
 }

--- a/apps/freeablo/fagui/guimanager.h
+++ b/apps/freeablo/fagui/guimanager.h
@@ -123,6 +123,7 @@ namespace FAGui
         void triggerItem(const FAWorld::EquipTarget& target);
         void item(nk_context* ctx, FAWorld::EquipTarget target, boost::variant<struct nk_rect, struct nk_vec2> placement, ItemHighlightInfo highligh);
         void inventoryPanel(nk_context* ctx);
+        void fillTextField(nk_context* ctx, float x, float y, float width, const char* text, TextColor color = TextColor::white);
         void characterPanel(nk_context* ctx);
         void questsPanel(nk_context* ctx);
         void spellsPanel(nk_context* ctx);

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -23,6 +23,7 @@ namespace FAWorld
             specialFor1x2,
             specialFor2x2,
         };
+
     private:
         using self = Inventory;
 
@@ -61,7 +62,7 @@ namespace FAWorld
         ItemBonus getTotalItemBonus() const;
         void takeOutGold(int32_t quantity);
         bool tryPlace(const Item& item, int32_t x, int32_t y);
-        bool couldBePlacedToInventory(const Item &item) const;
+        bool couldBePlacedToInventory(const Item& item) const;
 
     private:
         void updateCursor();
@@ -73,7 +74,7 @@ namespace FAWorld
         bool exchangeWithCursor(EquipTarget takeoutTarget, boost::optional<EquipTarget> maybePlacementTarget);
         bool exchangeWithCursor(EquipTarget takeoutTarget);
         // tries to place item so it top left corner is on x, y. returns false if it's impossible.
-        bool couldBePlacedToInventory(const Item &item, int32_t x, int32_t y) const;
+        bool couldBePlacedToInventory(const Item& item, int32_t x, int32_t y) const;
 
     public:
         // This is not serialised - it should be reconnected by other means

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -14,6 +14,7 @@ namespace FAWorld
 
     class Inventory
     {
+    public:
         enum class PlacementCheckOrder
         {
             fromLeftBottom,  // for 1x1 items
@@ -22,16 +23,7 @@ namespace FAWorld
             specialFor1x2,
             specialFor2x2,
         };
-        enum class xorder
-        {
-            fromLeft,
-            fromRight,
-        };
-        enum class yorder
-        {
-            fromTop,
-            fromBottom
-        };
+    private:
         using self = Inventory;
 
     public:
@@ -67,18 +59,21 @@ namespace FAWorld
         // note: this function could not just call autoPlaceItem because quantity may include more than 5000 pieces
         void placeGold(int quantity, const ItemFactory& itemFactory);
         ItemBonus getTotalItemBonus() const;
+        void takeOutGold(int32_t quantity);
+        bool tryPlace(const Item& item, int32_t x, int32_t y);
+        bool couldBePlacedToInventory(const Item &item) const;
 
     private:
         void updateCursor();
         bool checkStatsRequirement(const Item& item) const;
-        bool isFit(const Item& item, const EquipTarget& target) const;
+        bool couldBePlacedToInventory(const Item& item, const EquipTarget& target) const;
         auto needsToBeExchanged(const Item& item, const EquipTarget& target) const -> ExchangeResult;
         EquipTarget avoidLinks(const EquipTarget& target);
         void layItem(const Item& item, int32_t x, int32_t y);
         bool exchangeWithCursor(EquipTarget takeoutTarget, boost::optional<EquipTarget> maybePlacementTarget);
         bool exchangeWithCursor(EquipTarget takeoutTarget);
         // tries to place item so it top left corner is on x, y. returns false if it's impossible.
-        bool tryPlace(const Item& item, int32_t x, int32_t y);
+        bool couldBePlacedToInventory(const Item &item, int32_t x, int32_t y) const;
 
     public:
         // This is not serialised - it should be reconnected by other means

--- a/apps/freeablo/faworld/item.cpp
+++ b/apps/freeablo/faworld/item.cpp
@@ -237,7 +237,7 @@ namespace FAWorld
 
     bool Item::isUsable() const { return base().isUsable; }
 
-    uint32_t Item::getPrice() const { return base().price; }
+    int32_t Item::getPrice() const { return static_cast<int32_t> (base().price); }
 
     ItemType Item::getType() const
     {

--- a/apps/freeablo/faworld/item.cpp
+++ b/apps/freeablo/faworld/item.cpp
@@ -237,7 +237,7 @@ namespace FAWorld
 
     bool Item::isUsable() const { return base().isUsable; }
 
-    int32_t Item::getPrice() const { return static_cast<int32_t> (base().price); }
+    int32_t Item::getPrice() const { return static_cast<int32_t>(base().price); }
 
     ItemType Item::getType() const
     {

--- a/apps/freeablo/faworld/item.h
+++ b/apps/freeablo/faworld/item.h
@@ -93,7 +93,7 @@ namespace FAWorld
         int32_t getMinAttackDamage() const;
         int32_t getMaxAttackDamage() const;
         ItemBonus getBonus() const;
-        ItemId baseId () const { return mBaseId; }
+        ItemId baseId() const { return mBaseId; }
 
     private:
         std::string chargesStr() const;

--- a/apps/freeablo/faworld/item.h
+++ b/apps/freeablo/faworld/item.h
@@ -85,7 +85,7 @@ namespace FAWorld
         ItemMiscId getMiscId() const;
         uint32_t getSpellCode() const;
         bool isUsable() const;
-        uint32_t getPrice() const;
+        int32_t getPrice() const;
         ItemType getType() const;
         ItemEquipType getEquipLoc() const;
         ItemClass getClass() const;
@@ -93,6 +93,7 @@ namespace FAWorld
         int32_t getMinAttackDamage() const;
         int32_t getMaxAttackDamage() const;
         ItemBonus getBonus() const;
+        ItemId baseId () const { return mBaseId; }
 
     private:
         std::string chargesStr() const;

--- a/apps/freeablo/faworld/itemenums.h
+++ b/apps/freeablo/faworld/itemenums.h
@@ -325,6 +325,7 @@ namespace FAWorld
         baseAmuletQlvl8 = 154,
         baseAmuletQlvl16 = 155,
         null14 = 156,
+        COUNT,
     };
 
     enum class UniqueItemId

--- a/apps/freeablo/faworld/itemfactory.cpp
+++ b/apps/freeablo/faworld/itemfactory.cpp
@@ -23,7 +23,7 @@ namespace FAWorld
         res.mInvY = 0;
         res.mBaseId = id;
         res.mExe = &mExe;
-        auto info = getInfo (id);
+        auto info = getInfo(id);
         res.mMaxDurability = res.mCurrentDurability = info.durability;
         res.mArmorClass = Random::randomInRange(info.minArmorClass, info.maxArmorClass);
         return res;
@@ -40,7 +40,5 @@ namespace FAWorld
         return res;
     }
 
-    const DiabloExe::BaseItem& ItemFactory::getInfo(ItemId id) const {
-        return mExe.getBaseItems()[static_cast<int>(id)];
-    }
+    const DiabloExe::BaseItem& ItemFactory::getInfo(ItemId id) const { return mExe.getBaseItems()[static_cast<int>(id)]; }
 }

--- a/apps/freeablo/faworld/itemfactory.cpp
+++ b/apps/freeablo/faworld/itemfactory.cpp
@@ -23,7 +23,7 @@ namespace FAWorld
         res.mInvY = 0;
         res.mBaseId = id;
         res.mExe = &mExe;
-        auto info = mExe.getBaseItems()[static_cast<int>(id)];
+        auto info = getInfo (id);
         res.mMaxDurability = res.mCurrentDurability = info.durability;
         res.mArmorClass = Random::randomInRange(info.minArmorClass, info.maxArmorClass);
         return res;
@@ -38,5 +38,9 @@ namespace FAWorld
         auto baseItemId = it->second;
         auto res = generateBaseItem(baseItemId);
         return res;
+    }
+
+    const DiabloExe::BaseItem& ItemFactory::getInfo(ItemId id) const {
+        return mExe.getBaseItems()[static_cast<int>(id)];
     }
 }

--- a/apps/freeablo/faworld/itemfactory.cpp
+++ b/apps/freeablo/faworld/itemfactory.cpp
@@ -7,6 +7,19 @@
 
 namespace FAWorld
 {
+    std::function<bool(const DiabloExe::BaseItem& item)> ItemFilter::maxQLvl(int32_t value)
+    {
+        return [value](const DiabloExe::BaseItem& item) { return static_cast<int32_t>(item.qualityLevel) <= value; };
+    }
+
+    std::function<bool(const DiabloExe::BaseItem& item)> ItemFilter::sellableGriswoldBasic()
+    {
+        return [](const DiabloExe::BaseItem& item) {
+            static const auto excludedTypes = {ItemType::misc, ItemType::gold, ItemType::staff, ItemType::ring, ItemType::amulet};
+            return std::count(excludedTypes.begin(), excludedTypes.end(), static_cast<ItemType>(item.type)) == 0;
+        };
+    }
+
     ItemFactory::ItemFactory(const DiabloExe::DiabloExe& exe) : mExe(exe)
     {
         for (int i = 0; i < static_cast<int>(mExe.getBaseItems().size()); ++i)

--- a/apps/freeablo/faworld/itemfactory.h
+++ b/apps/freeablo/faworld/itemfactory.h
@@ -2,6 +2,12 @@
 
 #include <map>
 #include <memory>
+#include <vector>
+
+#include "misc/enum_range.h"
+#include "diabloexe/baseitem.h"
+#include "misc/random.h"
+#include "itemenums.h"
 
 namespace DiabloExe
 {
@@ -25,14 +31,49 @@ namespace FAWorld
         using thisType = BaseItemGenOptions;
     };
 
+    namespace ItemFilter
+    {
+        inline auto maxQLvl (int32_t value)
+        {
+            return [value](const DiabloExe::BaseItem &item) { return static_cast<int32_t> (item.qualityLevel) <= value; };
+        }
+
+        inline auto sellableGriswoldBasic ()
+        {
+            return [](const DiabloExe::BaseItem &item)
+            {
+                static const auto excludedTypes = {ItemType::misc, ItemType::gold, ItemType::staff, ItemType::ring, ItemType::amulet};
+                return std::count (excludedTypes.begin (), excludedTypes.end (), static_cast<ItemType> (item.type)) == 0;
+            };
+        }
+    };
+
     class ItemFactory
     {
     public:
         explicit ItemFactory(const DiabloExe::DiabloExe& exe);
         Item generateBaseItem(ItemId id, const BaseItemGenOptions& options = {}) const;
         Item generateUniqueItem(UniqueItemId id) const;
+        template <typename... FilterTypes>
+        ItemId randomItemId (const FilterTypes &... filters) const
+        {
+            static std::vector<ItemId> pool;
+            pool.clear ();
+            for (auto id : enum_range<ItemId> ())
+                {
+                    auto &info = getInfo (id);
+                    bool filteredOut = false;
+                    auto dummy = {(filteredOut = filteredOut || !filters(info),0)...};
+                    if (filteredOut)
+                        continue;
+                    for (int32_t i = 0; i < static_cast<int32_t> (info.dropRate); ++i)
+                         pool.push_back (id);
+                }
+            return pool[Random::randomInRange(0, pool.size () - 1)];
+        }
 
     private:
+        const DiabloExe::BaseItem &getInfo (ItemId id) const;
         // TODO: replace this with something more decent
         mutable std::unique_ptr<Cel::CelFile> mObjcursCel;
         std::map<int32_t, ItemId> mUniqueBaseItemIdToItemId;

--- a/apps/freeablo/faworld/itemfactory.h
+++ b/apps/freeablo/faworld/itemfactory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <vector>
@@ -33,19 +34,9 @@ namespace FAWorld
 
     namespace ItemFilter
     {
-        inline auto maxQLvl(int32_t value)
-        {
-            return [value](const DiabloExe::BaseItem& item) { return static_cast<int32_t>(item.qualityLevel) <= value; };
-        }
-
-        inline auto sellableGriswoldBasic()
-        {
-            return [](const DiabloExe::BaseItem& item) {
-                static const auto excludedTypes = {ItemType::misc, ItemType::gold, ItemType::staff, ItemType::ring, ItemType::amulet};
-                return std::count(excludedTypes.begin(), excludedTypes.end(), static_cast<ItemType>(item.type)) == 0;
-            };
-        }
-    };
+        std::function<bool(const DiabloExe::BaseItem& item)> maxQLvl(int32_t value);
+        std::function<bool(const DiabloExe::BaseItem& item)> sellableGriswoldBasic();
+    }
 
     class ItemFactory
     {
@@ -61,7 +52,7 @@ namespace FAWorld
             {
                 auto& info = getInfo(id);
                 bool filteredOut = false;
-                auto dummy = {(filteredOut = filteredOut || !filters(info), 0)...};
+                static_cast<void>(std::initializer_list<int>{(filteredOut = filteredOut || !filters(info), 0)...});
                 if (filteredOut)
                     continue;
                 for (int32_t i = 0; i < static_cast<int32_t>(info.dropRate); ++i)

--- a/apps/freeablo/faworld/itemfactory.h
+++ b/apps/freeablo/faworld/itemfactory.h
@@ -4,10 +4,10 @@
 #include <memory>
 #include <vector>
 
-#include "misc/enum_range.h"
 #include "diabloexe/baseitem.h"
-#include "misc/random.h"
 #include "itemenums.h"
+#include "misc/enum_range.h"
+#include "misc/random.h"
 
 namespace DiabloExe
 {
@@ -33,17 +33,16 @@ namespace FAWorld
 
     namespace ItemFilter
     {
-        inline auto maxQLvl (int32_t value)
+        inline auto maxQLvl(int32_t value)
         {
-            return [value](const DiabloExe::BaseItem &item) { return static_cast<int32_t> (item.qualityLevel) <= value; };
+            return [value](const DiabloExe::BaseItem& item) { return static_cast<int32_t>(item.qualityLevel) <= value; };
         }
 
-        inline auto sellableGriswoldBasic ()
+        inline auto sellableGriswoldBasic()
         {
-            return [](const DiabloExe::BaseItem &item)
-            {
+            return [](const DiabloExe::BaseItem& item) {
                 static const auto excludedTypes = {ItemType::misc, ItemType::gold, ItemType::staff, ItemType::ring, ItemType::amulet};
-                return std::count (excludedTypes.begin (), excludedTypes.end (), static_cast<ItemType> (item.type)) == 0;
+                return std::count(excludedTypes.begin(), excludedTypes.end(), static_cast<ItemType>(item.type)) == 0;
             };
         }
     };
@@ -54,26 +53,25 @@ namespace FAWorld
         explicit ItemFactory(const DiabloExe::DiabloExe& exe);
         Item generateBaseItem(ItemId id, const BaseItemGenOptions& options = {}) const;
         Item generateUniqueItem(UniqueItemId id) const;
-        template <typename... FilterTypes>
-        ItemId randomItemId (const FilterTypes &... filters) const
+        template <typename... FilterTypes> ItemId randomItemId(const FilterTypes&... filters) const
         {
             static std::vector<ItemId> pool;
-            pool.clear ();
-            for (auto id : enum_range<ItemId> ())
-                {
-                    auto &info = getInfo (id);
-                    bool filteredOut = false;
-                    auto dummy = {(filteredOut = filteredOut || !filters(info),0)...};
-                    if (filteredOut)
-                        continue;
-                    for (int32_t i = 0; i < static_cast<int32_t> (info.dropRate); ++i)
-                         pool.push_back (id);
-                }
-            return pool[Random::randomInRange(0, pool.size () - 1)];
+            pool.clear();
+            for (auto id : enum_range<ItemId>())
+            {
+                auto& info = getInfo(id);
+                bool filteredOut = false;
+                auto dummy = {(filteredOut = filteredOut || !filters(info), 0)...};
+                if (filteredOut)
+                    continue;
+                for (int32_t i = 0; i < static_cast<int32_t>(info.dropRate); ++i)
+                    pool.push_back(id);
+            }
+            return pool[Random::randomInRange(0, pool.size() - 1)];
         }
 
     private:
-        const DiabloExe::BaseItem &getInfo (ItemId id) const;
+        const DiabloExe::BaseItem& getInfo(ItemId id) const;
         // TODO: replace this with something more decent
         mutable std::unique_ptr<Cel::CelFile> mObjcursCel;
         std::map<int32_t, ItemId> mUniqueBaseItemIdToItemId;

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -42,7 +42,7 @@ namespace FAWorld
         initCommon();
     }
 
-    Player::Player(World& world, const std::string& className, const DiabloExe::CharacterStats& charStats) : Actor(world)
+    Player::Player(World& world, const DiabloExe::CharacterStats& charStats) : Actor(world)
     {
         init(charStats);
         initCommon();

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -20,6 +20,20 @@ namespace FAWorld
 {
     const std::string Player::typeId = "player";
 
+    const char* toString(PlayerClass value)
+    {
+        switch (value)
+        {
+            case PlayerClass::warrior:
+                return "Warrior";
+            case PlayerClass::rogue:
+                return "Rogue";
+            case PlayerClass::sorcerer:
+                return "Sorcerer";
+        }
+        return "Unknown";
+    }
+
     Player::Player(World& world) : Actor(world)
     {
         // TODO: hack - need to think of some more elegant way of handling Actors in general

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -71,8 +71,7 @@ namespace FAWorld
     void Player::init(const std::string& className, const DiabloExe::CharacterStats& charStats)
     {
         UNUSED_PARAM(className);
-        UNUSED_PARAM(charStats);
-
+        mPlayerStats = {charStats};
         mFaction = Faction::heaven();
         mMoveHandler = MovementHandler(World::getTicksInPeriod(0.1f)); // allow players to repath much more often than other actors
 
@@ -84,6 +83,7 @@ namespace FAWorld
     Player::Player(World& world, FASaveGame::GameLoader& loader, const DiabloExe::DiabloExe& exe) : Actor(world, loader, exe)
     {
         mClassName = loader.load<std::string>();
+        mPlayerStats = {loader};
         initCommon();
     }
 
@@ -93,13 +93,14 @@ namespace FAWorld
 
         Actor::save(saver);
         saver.save(mClassName);
+        mPlayerStats.save(saver);
     }
 
     bool Player::checkHit(Actor* enemy)
     {
         // let's throw some formulas, parameters will be placeholders for now
         auto roll = Random::randomInRange(0, 99);
-        auto toHit = getDexterity() / 2;
+        auto toHit = mPlayerStats.mDexterity / 2;
         toHit += getArmorPenetration();
         toHit -= enemy->getArmor();
         toHit += getCharacterLevel();

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -240,6 +240,8 @@ namespace FAWorld
 
             else if (mInventory.getLeftHand().getType() == ItemType::bow && mInventory.getRightHand().getType() == ItemType::bow)
                 weapon = "b";
+            else if (mInventory.getLeftHand().getType() == ItemType::axe && mInventory.getRightHand().getType() == ItemType::axe)
+                weapon = "a";
 
             else if (mInventory.getLeftHand().getType() == ItemType::staff && mInventory.getRightHand().getType() == ItemType::staff)
                 weapon = "t";

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -17,6 +17,8 @@ namespace FAWorld
         sorcerer,
     };
 
+    const char* toString(PlayerClass value);
+
     class Player : public Actor
     {
     public:
@@ -39,6 +41,7 @@ namespace FAWorld
 
         PlayerBehaviour* getPlayerBehaviour() { return (PlayerBehaviour*)mBehaviour.get(); }
         int getTotalGold() const;
+        const PlayerStats& getPlayerStats() const { return mPlayerStats; }
 
         boost::signals2::signal<void(const std::pair<int32_t, int32_t>&)> positionReached;
         int getArmorPenetration() const { /* placeholder */ return 0; }

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "actor.h"
+#include "playerstats.h"
 
 #include <boost/signals2/signal.hpp>
 
@@ -40,7 +41,6 @@ namespace FAWorld
         int getTotalGold() const;
 
         boost::signals2::signal<void(const std::pair<int32_t, int32_t>&)> positionReached;
-        int getDexterity() const { /*placeholder */ return 0; }
         int getArmorPenetration() const { /* placeholder */ return 0; }
         int getCharacterLevel() const { /* placeholder */ return 1; }
         PlayerClass getClass() const { /* placeholder */ return PlayerClass::warrior; }
@@ -57,5 +57,6 @@ namespace FAWorld
 
     private:
         std::string mClassName;
+        PlayerStats mPlayerStats;
     };
 }

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -28,7 +28,7 @@ namespace FAWorld
         const std::string& getTypeId() override { return typeId; }
 
         Player(World& world);
-        Player(World& world, const std::string& className, const DiabloExe::CharacterStats& charStats);
+        Player(World& world, const DiabloExe::CharacterStats& charStats);
         void initCommon();
         Player(World& world, FASaveGame::GameLoader& loader, const DiabloExe::DiabloExe& exe);
         void save(FASaveGame::GameSaver& saver) override;

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -17,6 +17,8 @@ namespace FAWorld
         sorcerer,
     };
 
+    // note that this function features misspelling of sorcerer as sorceror
+    // because it's written this way on character panel
     const char* toString(PlayerClass value);
 
     class Player : public Actor
@@ -33,7 +35,6 @@ namespace FAWorld
         virtual bool checkHit(Actor* enemy) override;
 
         virtual ~Player();
-        void setSpriteClass(std::string className);
         void updateSprites() override;
         bool dropItem(const FAWorld::Tile& clickedTile);
 
@@ -42,11 +43,12 @@ namespace FAWorld
         PlayerBehaviour* getPlayerBehaviour() { return (PlayerBehaviour*)mBehaviour.get(); }
         int getTotalGold() const;
         const PlayerStats& getPlayerStats() const { return mPlayerStats; }
+        void setPlayerClass(PlayerClass playerClass);
 
         boost::signals2::signal<void(const std::pair<int32_t, int32_t>&)> positionReached;
         int getArmorPenetration() const { /* placeholder */ return 0; }
         int getCharacterLevel() const { /* placeholder */ return 1; }
-        PlayerClass getClass() const { /* placeholder */ return PlayerClass::warrior; }
+        PlayerClass getClass() const { return mPlayerClass; }
         double meleeDamageVs(const Actor* actor) const override;
         int getMaxDamage() const { /* placeholder */ return 20; }
         int getPercentDamageBonus() const { return 0; }
@@ -55,11 +57,11 @@ namespace FAWorld
         ItemBonus getItemBonus() const;
 
     private:
-        void init(const std::string& className, const DiabloExe::CharacterStats& charStats);
+        void init(const DiabloExe::CharacterStats& charStats);
         bool canTalkTo(Actor* actor);
 
     private:
-        std::string mClassName;
         PlayerStats mPlayerStats;
+        PlayerClass mPlayerClass;
     };
 }

--- a/apps/freeablo/faworld/playerfactory.cpp
+++ b/apps/freeablo/faworld/playerfactory.cpp
@@ -71,7 +71,7 @@ namespace FAWorld
             player->mInventory.putItemUnsafe(mItemFactory.generateBaseItem(ItemId::potionOfHealing), MakeEquipTarget<EquipTargetType::belt>(i));
         }
 
-        player->setSpriteClass("warrior");
+        player->setPlayerClass(PlayerClass::warrior);
         player->mAnimation.setAnimation(AnimState::idle, FARender::Renderer::get()->loadImage("plrgfx/warrior/wld/wldst.cl2"));
         player->mAnimation.setAnimation(AnimState::walk, FARender::Renderer::get()->loadImage("plrgfx/warrior/wld/wldwl.cl2"));
         // loadTestingKit (player);
@@ -92,7 +92,7 @@ namespace FAWorld
             player->mInventory.putItemUnsafe(mItemFactory.generateBaseItem(ItemId::potionOfHealing), MakeEquipTarget<EquipTargetType::belt>(i));
         }
 
-        player->setSpriteClass("rogue");
+        player->setPlayerClass(PlayerClass::rogue);
         player->mAnimation.setAnimation(AnimState::idle, FARender::Renderer::get()->loadImage("plrgfx/rogue/rlb/rlbst.cl2"));
         player->mAnimation.setAnimation(AnimState::walk, FARender::Renderer::get()->loadImage("plrgfx/rogue/rlb/rlbwl.cl2"));
     }
@@ -115,7 +115,7 @@ namespace FAWorld
             player->mInventory.putItemUnsafe(mItemFactory.generateBaseItem(ItemId::potionOfMana), MakeEquipTarget<EquipTargetType::belt>(i));
         }
 
-        player->setSpriteClass("sorceror");
+        player->setPlayerClass(PlayerClass::sorcerer);
         player->mAnimation.setAnimation(AnimState::idle, FARender::Renderer::get()->loadImage("plrgfx/sorceror/slt/sltst.cl2"));
         player->mAnimation.setAnimation(AnimState::walk, FARender::Renderer::get()->loadImage("plrgfx/sorceror/slt/sltwl.cl2"));
     }

--- a/apps/freeablo/faworld/playerfactory.cpp
+++ b/apps/freeablo/faworld/playerfactory.cpp
@@ -14,7 +14,7 @@ namespace FAWorld
     Player* PlayerFactory::create(World& world, const std::string& playerClass) const
     {
         auto charStats = mExe.getCharacterStat(playerClass);
-        auto player = new Player(world, playerClass, charStats);
+        auto player = new Player(world, charStats);
 
         if (playerClass == "Warrior")
             createWarrior(player);

--- a/apps/freeablo/faworld/playerstats.cpp
+++ b/apps/freeablo/faworld/playerstats.cpp
@@ -1,0 +1,27 @@
+#include "playerstats.h"
+#include "../fasavegame/gameloader.h"
+#include "diabloexe/characterstats.h"
+
+namespace FAWorld
+{
+    PlayerStats::PlayerStats(const DiabloExe::CharacterStats& charStats)
+        : mStrength(charStats.mStrength), mDexterity(charStats.mDexterity), mMagic(charStats.mMagic), mVitality(charStats.mVitality)
+    {
+    }
+
+    PlayerStats::PlayerStats(FASaveGame::GameLoader& loader)
+    {
+        mStrength = loader.load<int32_t>();
+        mDexterity = loader.load<int32_t>();
+        mMagic = loader.load<int32_t>();
+        mVitality = loader.load<int32_t>();
+    }
+
+    void PlayerStats::save(FASaveGame::GameSaver& saver) const
+    {
+        saver.save(mStrength);
+        saver.save(mDexterity);
+        saver.save(mMagic);
+        saver.save(mVitality);
+    }
+}

--- a/apps/freeablo/faworld/playerstats.h
+++ b/apps/freeablo/faworld/playerstats.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+namespace DiabloExe
+{
+    class CharacterStats;
+}
+
+namespace FASaveGame
+{
+    class GameLoader;
+    class GameSaver;
+}
+
+namespace FAWorld
+{
+    class PlayerStats
+    {
+    public:
+        PlayerStats() = default;
+        PlayerStats(const DiabloExe::CharacterStats& charStats);
+        PlayerStats(FASaveGame::GameLoader& loader);
+        void save(FASaveGame::GameSaver& saver) const;
+
+    public:
+        int32_t mStrength = 1;
+        int32_t mDexterity = 1;
+        int32_t mMagic = 1;
+        int32_t mVitality = 1;
+    };
+}

--- a/apps/freeablo/faworld/storedata.cpp
+++ b/apps/freeablo/faworld/storedata.cpp
@@ -1,19 +1,18 @@
 #include "storedata.h"
-#include "misc/random.h"
-#include "itemfactory.h"
 #include "item.h"
+#include "itemfactory.h"
+#include "misc/random.h"
 
 namespace FAWorld
 {
-    StoreData::StoreData(const ItemFactory& itemFactory) : mItemFactory(itemFactory) {
-    }
+    StoreData::StoreData(const ItemFactory& itemFactory) : mItemFactory(itemFactory) {}
 
     void StoreData::regenerateGriswoldBasicItems(int32_t ilvl)
     {
         int32_t count = Random::randomInRange(10, 20);
-        griswoldBasicItems.resize (count);
-        for (auto &item : griswoldBasicItems)
-            item = mItemFactory.generateBaseItem(mItemFactory.randomItemId (ItemFilter::maxQLvl(ilvl), ItemFilter::sellableGriswoldBasic()));
-        std::sort (griswoldBasicItems.begin (), griswoldBasicItems.end(), [](const Item &lhs, const Item &rhs){ return lhs.baseId() < rhs.baseId (); });
+        griswoldBasicItems.resize(count);
+        for (auto& item : griswoldBasicItems)
+            item = mItemFactory.generateBaseItem(mItemFactory.randomItemId(ItemFilter::maxQLvl(ilvl), ItemFilter::sellableGriswoldBasic()));
+        std::sort(griswoldBasicItems.begin(), griswoldBasicItems.end(), [](const Item& lhs, const Item& rhs) { return lhs.baseId() < rhs.baseId(); });
     }
 }

--- a/apps/freeablo/faworld/storedata.cpp
+++ b/apps/freeablo/faworld/storedata.cpp
@@ -1,0 +1,19 @@
+#include "storedata.h"
+#include "misc/random.h"
+#include "itemfactory.h"
+#include "item.h"
+
+namespace FAWorld
+{
+    StoreData::StoreData(const ItemFactory& itemFactory) : mItemFactory(itemFactory) {
+    }
+
+    void StoreData::regenerateGriswoldBasicItems(int32_t ilvl)
+    {
+        int32_t count = Random::randomInRange(10, 20);
+        griswoldBasicItems.resize (count);
+        for (auto &item : griswoldBasicItems)
+            item = mItemFactory.generateBaseItem(mItemFactory.randomItemId (ItemFilter::maxQLvl(ilvl), ItemFilter::sellableGriswoldBasic()));
+        std::sort (griswoldBasicItems.begin (), griswoldBasicItems.end(), [](const Item &lhs, const Item &rhs){ return lhs.baseId() < rhs.baseId (); });
+    }
+}

--- a/apps/freeablo/faworld/storedata.h
+++ b/apps/freeablo/faworld/storedata.h
@@ -11,12 +11,14 @@ namespace FAWorld
     class StoreData
     {
     public:
-        explicit StoreData (const ItemFactory &itemFactory);
+        explicit StoreData(const ItemFactory& itemFactory);
 
-        void regenerateGriswoldBasicItems (int32_t ilvl);
+        void regenerateGriswoldBasicItems(int32_t ilvl);
+
     public:
         std::vector<Item> griswoldBasicItems;
+
     private:
-        const ItemFactory &mItemFactory;
+        const ItemFactory& mItemFactory;
     };
 }

--- a/apps/freeablo/faworld/storedata.h
+++ b/apps/freeablo/faworld/storedata.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vector>
+
+namespace FAWorld
+{
+    class Item;
+    class ItemFactory;
+
+    /// class for storing and regenerating items sold in various stores
+    class StoreData
+    {
+    public:
+        explicit StoreData (const ItemFactory &itemFactory);
+
+        void regenerateGriswoldBasicItems (int32_t ilvl);
+    public:
+        std::vector<Item> griswoldBasicItems;
+    private:
+        const ItemFactory &mItemFactory;
+    };
+}

--- a/apps/freeablo/faworld/storedata.h
+++ b/apps/freeablo/faworld/storedata.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 namespace FAWorld

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -18,6 +18,7 @@
 #include "itemmap.h"
 #include "player.h"
 #include "playerbehaviour.h"
+#include "storedata.h"
 #include <algorithm>
 #include <boost/make_unique.hpp>
 #include <diabloexe/diabloexe.h>
@@ -27,7 +28,17 @@
 
 namespace FAWorld
 {
-    World::World(const DiabloExe::DiabloExe& exe) : mDiabloExe(exe), mItemFactory(boost::make_unique<ItemFactory>(exe)) { this->setupObjectIdMappers(); }
+    World::World(const DiabloExe::DiabloExe& exe)
+        : mDiabloExe(exe), mItemFactory(boost::make_unique<ItemFactory>(exe)), mStoreData(std::make_unique<StoreData>(*mItemFactory))
+    {
+        this->setupObjectIdMappers();
+        regenerateStoreItems ();
+    }
+
+    void World::regenerateStoreItems ()
+    {
+      mStoreData->regenerateGriswoldBasicItems(10/*placeholder*/);
+    }
 
     World::World(FASaveGame::GameLoader& loader, const DiabloExe::DiabloExe& exe) : World(exe)
     {

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -29,7 +29,7 @@
 namespace FAWorld
 {
     World::World(const DiabloExe::DiabloExe& exe)
-        : mDiabloExe(exe), mItemFactory(boost::make_unique<ItemFactory>(exe)), mStoreData(std::make_unique<StoreData>(*mItemFactory))
+        : mDiabloExe(exe), mItemFactory(boost::make_unique<ItemFactory>(exe)), mStoreData(boost::make_unique<StoreData>(*mItemFactory))
     {
         this->setupObjectIdMappers();
         regenerateStoreItems();

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -32,13 +32,10 @@ namespace FAWorld
         : mDiabloExe(exe), mItemFactory(boost::make_unique<ItemFactory>(exe)), mStoreData(std::make_unique<StoreData>(*mItemFactory))
     {
         this->setupObjectIdMappers();
-        regenerateStoreItems ();
+        regenerateStoreItems();
     }
 
-    void World::regenerateStoreItems ()
-    {
-      mStoreData->regenerateGriswoldBasicItems(10/*placeholder*/);
-    }
+    void World::regenerateStoreItems() { mStoreData->regenerateGriswoldBasicItems(10 /*placeholder*/); }
 
     World::World(FASaveGame::GameLoader& loader, const DiabloExe::DiabloExe& exe) : World(exe)
     {

--- a/apps/freeablo/faworld/world.h
+++ b/apps/freeablo/faworld/world.h
@@ -42,6 +42,7 @@ namespace FAWorld
     class PlacedItemData;
     class ItemFactory;
     class HoverStatus;
+    class StoreData;
 
     // at 125 ticks/second, it will take about 2 billion years to reach max (signed) value, so int64 will probably do :p
     typedef int64_t Tick;
@@ -66,6 +67,7 @@ namespace FAWorld
         void setLevel(int32_t levelNum);
         GameLevel* getLevel(size_t level);
         void insertLevel(size_t level, GameLevel* gameLevel);
+        void regenerateStoreItems();
 
         Actor* getActorAt(size_t x, size_t y);
 
@@ -98,6 +100,7 @@ namespace FAWorld
         void blockInput();
         void unblockInput();
         const ItemFactory& getItemFactory() const;
+        StoreData& getStoreData() { return *mStoreData; }
 
         void playLevelMusic(size_t level);
 
@@ -114,6 +117,7 @@ namespace FAWorld
         Player* mCurrentPlayer = nullptr;
         std::vector<Player*> mPlayers; ///< This vector is sorted
         std::unique_ptr<ItemFactory> mItemFactory;
+        std::unique_ptr<StoreData> mStoreData;
 
         int32_t mNextId = 1;
     };

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(Misc
     misc/direction.h
     misc/random.cpp
     misc/random.h
+    misc/enum_range.h
 )
 target_link_libraries(Misc Settings PNG::png SDL2::SDL2)
 SET_TARGET_PROPERTIES(Misc PROPERTIES LINKER_LANGUAGE CXX)

--- a/components/diabloexe/characterstats.h
+++ b/components/diabloexe/characterstats.h
@@ -12,6 +12,9 @@ namespace DiabloExe
         CharacterStats() {}
 
         std::string dump() const;
+        // Looks like these all are actually frame counts for animations and not required to be read at all
+        // The only thing needed is attack frame by weapon/shield equipped and it can't be extracted from exe nicely
+        // since it's hardcoded
         uint8_t mIdleInDungeonFrameset;
         uint8_t mAttackFrameset;
         uint8_t mWalkInDungeonFrameset;

--- a/components/misc/enum_range.h
+++ b/components/misc/enum_range.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <iterator>
+
+template<typename EnumT>
+class enum_range_t;
+
+template<typename EnumT>
+class enum_range_iterator : public std::iterator < std::forward_iterator_tag, EnumT >
+{
+  EnumT m_value;
+public:
+  EnumT operator *() const { return m_value; }
+  enum_range_iterator<EnumT> operator++ ()
+  {
+    enum_range_iterator val{ m_value };
+    m_value = static_cast<EnumT> (static_cast<int> (m_value)+1);
+    return val;
+  }
+
+  bool operator == (const enum_range_iterator &rhs) const { return m_value == rhs.m_value; }
+  bool operator != (const enum_range_iterator &rhs) const { return m_value != rhs.m_value; }
+
+private:
+  enum_range_iterator (EnumT value) { m_value = value; }
+  friend class enum_range_t < EnumT > ;
+};
+
+
+template<typename EnumT>
+class enum_range_t
+{
+public:
+  using iterator = enum_range_iterator < EnumT > ;
+  using value_type = EnumT;
+
+  enum_range_t () : m_begin { static_cast<EnumT> (0) }, m_end { EnumT::COUNT} {}
+  enum_range_t (EnumT begin) : enum_range_t{} { m_begin = iterator{ begin }; }
+  enum_range_t (EnumT begin, EnumT end) : m_begin{ begin }, m_end{ end } {}
+
+  iterator begin () const { return m_begin; }
+  iterator end () const { return m_end; }
+
+private:
+  iterator m_begin;
+  iterator m_end;
+};
+
+template<typename EnumT>
+enum_range_t<EnumT> enum_range () { return enum_range_t<EnumT> (); }
+
+template<typename EnumT>
+enum_range_t<EnumT> enum_range (EnumT begin) { return enum_range_t<EnumT> (begin); }
+
+template<typename EnumT>
+enum_range_t<EnumT> enum_range (EnumT begin, EnumT end) { return enum_range_t<EnumT> (begin, end); }

--- a/components/misc/enum_range.h
+++ b/components/misc/enum_range.h
@@ -2,55 +2,49 @@
 
 #include <iterator>
 
-template<typename EnumT>
-class enum_range_t;
+template <typename EnumT> class enum_range_t;
 
-template<typename EnumT>
-class enum_range_iterator : public std::iterator < std::forward_iterator_tag, EnumT >
+template <typename EnumT> class enum_range_iterator : public std::iterator<std::forward_iterator_tag, EnumT>
 {
-  EnumT m_value;
-public:
-  EnumT operator *() const { return m_value; }
-  enum_range_iterator<EnumT> operator++ ()
-  {
-    enum_range_iterator val{ m_value };
-    m_value = static_cast<EnumT> (static_cast<int> (m_value)+1);
-    return val;
-  }
+    EnumT m_value;
 
-  bool operator == (const enum_range_iterator &rhs) const { return m_value == rhs.m_value; }
-  bool operator != (const enum_range_iterator &rhs) const { return m_value != rhs.m_value; }
+public:
+    EnumT operator*() const { return m_value; }
+    enum_range_iterator<EnumT> operator++()
+    {
+        enum_range_iterator val{m_value};
+        m_value = static_cast<EnumT>(static_cast<int>(m_value) + 1);
+        return val;
+    }
+
+    bool operator==(const enum_range_iterator& rhs) const { return m_value == rhs.m_value; }
+    bool operator!=(const enum_range_iterator& rhs) const { return m_value != rhs.m_value; }
 
 private:
-  enum_range_iterator (EnumT value) { m_value = value; }
-  friend class enum_range_t < EnumT > ;
+    enum_range_iterator(EnumT value) { m_value = value; }
+    friend class enum_range_t<EnumT>;
 };
 
-
-template<typename EnumT>
-class enum_range_t
+template <typename EnumT> class enum_range_t
 {
 public:
-  using iterator = enum_range_iterator < EnumT > ;
-  using value_type = EnumT;
+    using iterator = enum_range_iterator<EnumT>;
+    using value_type = EnumT;
 
-  enum_range_t () : m_begin { static_cast<EnumT> (0) }, m_end { EnumT::COUNT} {}
-  enum_range_t (EnumT begin) : enum_range_t{} { m_begin = iterator{ begin }; }
-  enum_range_t (EnumT begin, EnumT end) : m_begin{ begin }, m_end{ end } {}
+    enum_range_t() : m_begin{static_cast<EnumT>(0)}, m_end{EnumT::COUNT} {}
+    enum_range_t(EnumT begin) : enum_range_t{} { m_begin = iterator{begin}; }
+    enum_range_t(EnumT begin, EnumT end) : m_begin{begin}, m_end{end} {}
 
-  iterator begin () const { return m_begin; }
-  iterator end () const { return m_end; }
+    iterator begin() const { return m_begin; }
+    iterator end() const { return m_end; }
 
 private:
-  iterator m_begin;
-  iterator m_end;
+    iterator m_begin;
+    iterator m_end;
 };
 
-template<typename EnumT>
-enum_range_t<EnumT> enum_range () { return enum_range_t<EnumT> (); }
+template <typename EnumT> enum_range_t<EnumT> enum_range() { return enum_range_t<EnumT>(); }
 
-template<typename EnumT>
-enum_range_t<EnumT> enum_range (EnumT begin) { return enum_range_t<EnumT> (begin); }
+template <typename EnumT> enum_range_t<EnumT> enum_range(EnumT begin) { return enum_range_t<EnumT>(begin); }
 
-template<typename EnumT>
-enum_range_t<EnumT> enum_range (EnumT begin, EnumT end) { return enum_range_t<EnumT> (begin, end); }
+template <typename EnumT> enum_range_t<EnumT> enum_range(EnumT begin, EnumT end) { return enum_range_t<EnumT>(begin, end); }


### PR DESCRIPTION
1. Player stats are experimental but I do think they should be separated from actor stats because players have a lot of unique properties.
2. Buying basic items from Griswold is the easiest kind of item generation. Current limitations:
* items not saved/loaded.
* not regenerated on reentering town.
* `ilvl` is fixed for now.