### PR TITLE
Bug was fixed. Take correct item from array.

### DIFF
--- a/apps/freeablo/fagui/menu/startingmenuscreen.cpp
+++ b/apps/freeablo/fagui/menu/startingmenuscreen.cpp
@@ -42,9 +42,9 @@ namespace FAGui
                                   mMenuHandler.setActiveScreen<SelectHeroMenuScreen>();
                                   return ActionResult::stopDrawing;
                               }});
-        mMenuItems.push_back({drawItem("Multi Player", {65, 235, 510, 42}), [this]() { return ActionResult::continueDrawing; }});
-        mMenuItems.push_back({drawItem("Replay Intro", {65, 277, 510, 42}), [this]() { return ActionResult::continueDrawing; }});
-        mMenuItems.push_back({drawItem("Show Credits", {65, 320, 510, 42}), [this]() { return ActionResult::continueDrawing; }});
+        mMenuItems.push_back({drawItem("Multi Player", {65, 235, 510, 42}), []() { return ActionResult::continueDrawing; }});
+        mMenuItems.push_back({drawItem("Replay Intro", {65, 277, 510, 42}), []() { return ActionResult::continueDrawing; }});
+        mMenuItems.push_back({drawItem("Show Credits", {65, 320, 510, 42}), []() { return ActionResult::continueDrawing; }});
         mRejectAction = [this]() {
             mMenuHandler.engine().stop();
             return ActionResult::stopDrawing;

--- a/apps/freeablo/faworld/findpath.cpp
+++ b/apps/freeablo/faworld/findpath.cpp
@@ -64,7 +64,7 @@ namespace FAWorld
 
         Array2D(int32_t width, int32_t height, T defaultVal) : mData(width * height, defaultVal), mWidth(width), mHeight(height) {}
 
-        T& get(int32_t x, int32_t y) { return mData.at(x + y * mHeight); }
+        T& get(int32_t x, int32_t y) { return mData.at(x + y * mWidth); }
 
         int32_t width() { return mWidth; }
 


### PR DESCRIPTION
When it's required to get item in 2d array, `y` should be multiplied by `width` (not `height`).