### PR TITLE
Server::mHost is null on Windows 10 without calling enet_address_set_…

### DIFF
--- a/apps/freeablo/engine/enginemain.cpp
+++ b/apps/freeablo/engine/enginemain.cpp
@@ -142,6 +142,11 @@ namespace Engine
         mInputManager->registerMouseObserver(mLocalInputHandler.get());
         mInputManager->registerKeyboardObserver(mLocalInputHandler.get());
 
+        if (0 != enet_initialize())
+        {
+            std::cerr << "Unable to initialize networking library." << std::endl;
+            return;
+        }
         if (variables["client"].as<bool>())
         {
             mMultiplayer.reset(new Client(*mLocalInputHandler.get()));
@@ -233,6 +238,7 @@ namespace Engine
 
         renderer.stop();
         renderer.waitUntilDone();
+        enet_deinitialize();
     }
 
     void EngineMain::notify(KeyboardInputAction action)

--- a/apps/freeablo/engine/enginemain.cpp
+++ b/apps/freeablo/engine/enginemain.cpp
@@ -142,11 +142,6 @@ namespace Engine
         mInputManager->registerMouseObserver(mLocalInputHandler.get());
         mInputManager->registerKeyboardObserver(mLocalInputHandler.get());
 
-        if (0 != enet_initialize())
-        {
-            std::cerr << "Unable to initialize networking library." << std::endl;
-            return;
-        }
         if (variables["client"].as<bool>())
         {
             mMultiplayer.reset(new Client(*mLocalInputHandler.get()));
@@ -238,7 +233,6 @@ namespace Engine
 
         renderer.stop();
         renderer.waitUntilDone();
-        enet_deinitialize();
     }
 
     void EngineMain::notify(KeyboardInputAction action)

--- a/apps/freeablo/engine/net/client.cpp
+++ b/apps/freeablo/engine/net/client.cpp
@@ -5,9 +5,9 @@
 #include "../../faworld/world.h"
 #include "../enginemain.h"
 #include "../localinputhandler.h"
+#include <iostream>
 #include <misc/assert.h>
 #include <serial/textstream.h>
-#include <iostream>
 
 namespace Engine
 {

--- a/apps/freeablo/engine/net/client.cpp
+++ b/apps/freeablo/engine/net/client.cpp
@@ -7,11 +7,16 @@
 #include "../localinputhandler.h"
 #include <misc/assert.h>
 #include <serial/textstream.h>
+#include <iostream>
 
 namespace Engine
 {
     Client::Client(LocalInputHandler& localInputHandler) : mLocalInputHandler(localInputHandler)
     {
+        if (0 != enet_initialize())
+        {
+            std::cerr << "Unable to initialize networking library." << std::endl;
+        }
         mAddress.port = 6666;
         enet_address_set_host(&mAddress, "127.0.0.1");
         mHost = enet_host_create(nullptr, 32, 2, 0, 0);
@@ -25,6 +30,7 @@ namespace Engine
 
         enet_host_flush(mHost);
         enet_host_destroy(mHost);
+        enet_deinitialize();
     }
 
     boost::optional<std::vector<FAWorld::PlayerInput>> Client::getAndClearInputs(FAWorld::Tick tick)

--- a/apps/freeablo/engine/net/server.cpp
+++ b/apps/freeablo/engine/net/server.cpp
@@ -4,9 +4,9 @@
 #include "../../faworld/world.h"
 #include "../enginemain.h"
 #include "../localinputhandler.h"
+#include <iostream>
 #include <misc/assert.h>
 #include <serial/textstream.h>
-#include <iostream>
 
 namespace Engine
 {

--- a/apps/freeablo/engine/net/server.cpp
+++ b/apps/freeablo/engine/net/server.cpp
@@ -9,10 +9,12 @@
 
 namespace Engine
 {
+    const char* Server::SERVER_ADDRESS = "127.0.0.1";
+
     Server::Server(FAWorld::World& world, LocalInputHandler& localInputHandler) : mWorld(world), mLocalInputHandler(localInputHandler)
     {
         mAddress.port = 6666;
-        mAddress.host = ENET_HOST_ANY;
+        enet_address_set_host(&mAddress, SERVER_ADDRESS);
         mHost = enet_host_create(&mAddress, 32, 2, 0, 0);
     }
 

--- a/apps/freeablo/engine/net/server.cpp
+++ b/apps/freeablo/engine/net/server.cpp
@@ -6,6 +6,7 @@
 #include "../localinputhandler.h"
 #include <misc/assert.h>
 #include <serial/textstream.h>
+#include <iostream>
 
 namespace Engine
 {
@@ -13,6 +14,10 @@ namespace Engine
 
     Server::Server(FAWorld::World& world, LocalInputHandler& localInputHandler) : mWorld(world), mLocalInputHandler(localInputHandler)
     {
+        if (0 != enet_initialize())
+        {
+            std::cerr << "Unable to initialize networking library." << std::endl;
+        }
         mAddress.port = 6666;
         enet_address_set_host(&mAddress, SERVER_ADDRESS);
         mHost = enet_host_create(&mAddress, 32, 2, 0, 0);
@@ -21,7 +26,7 @@ namespace Engine
     Server::~Server()
     {
         enet_host_destroy(mHost);
-        mHost = nullptr;
+        enet_deinitialize();
     }
 
     boost::optional<std::vector<FAWorld::PlayerInput>> Server::getAndClearInputs(FAWorld::Tick tick)

--- a/apps/freeablo/engine/net/server.h
+++ b/apps/freeablo/engine/net/server.h
@@ -45,6 +45,8 @@ namespace Engine
         void sendInputsToClients(std::vector<FAWorld::PlayerInput>& inputs);
         void receiveClientUpdate(FASaveGame::GameLoader& loader, Peer& peer);
 
+        static const char* SERVER_ADDRESS;
+
         bool mDoFullVerify = false;
 
         FAWorld::World& mWorld;


### PR DESCRIPTION
…host()

Fixes #401.