### PR TITLE
fix bug in celview's save as png

### DIFF
--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -787,7 +787,8 @@ namespace Render
     {
         Cel::CelFile cel(celPath);
 
-        int32_t numFrames = cel.animLength();
+        int32_t numFrames = cel.numFrames();
+        
         if (numFrames == 0)
             return;
 


### PR DESCRIPTION
it would only output the frames in the animation for the first direction instead of the whole cl2