### PR TITLE
Add gif export to celview using a modified version of jo_gif.cpp

### DIFF
--- a/apps/celview/main.cpp
+++ b/apps/celview/main.cpp
@@ -90,6 +90,17 @@ int main(int, char**)
                         }
                     }
 
+                    if (nk_button_label(ctx, "save as gif"))
+                    {
+                        nfdchar_t* outPath = NULL;
+                        nfdresult_t result = NFD_SaveDialog("gif", NULL, &outPath);
+                        if (result == NFD_OKAY)
+                        {
+                            Render::SpriteGroup::toGif(selectedImage, outPath);
+                            free(outPath);
+                        }
+                    }
+
                     auto msSinceLastFrame = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastFrame).count();
                     if (animate && msSinceLastFrame > 100)
                     {

--- a/components/render/misc.h
+++ b/components/render/misc.h
@@ -25,6 +25,7 @@ namespace Render
         int32_t getHeight() const { return mHeight; }
 
         static void toPng(const std::string& celPath, const std::string& pngPath);
+        static void toGif(const std::string& celPath, const std::string& gifPath);
 
     private:
         std::vector<Sprite> mSprites;

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -18,6 +18,8 @@
 #include <misc/savePNG.h>
 #include <misc/stringops.h>
 
+#include "../../extern/jo_gif/jo_gif.cpp"
+
 /*#define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
 #define NK_INCLUDE_STANDARD_VARARGS
@@ -818,6 +820,43 @@ namespace Render
 
         SDL_FreeSurface(s);
     }
+
+    void SpriteGroup::toGif(const std::string& celPath, const std::string& gifPath)
+    {
+        Cel::CelFile cel(celPath);
+
+        int32_t width = cel[0].width();
+        int32_t height = cel[0].height();
+
+        int32_t numFrames = cel.numFrames();
+
+        if (numFrames == 0)
+            return;
+
+        jo_gif_t gif = jo_gif_start(gifPath.c_str(), width, height, 0, 256);
+
+        for (int32_t i = 0; i < numFrames; i++)
+        {
+            SDL_Surface* s = createTransparentSurface(width, height);
+            drawFrame(s, 0, 0, cel[i]);
+
+            uint8_t** gifImage = (uint8_t**)malloc(s->h * sizeof(uint8_t*));
+
+            for (int j = 0; j < s->h; j++)
+            {   
+                gifImage[j] = (uint8_t*)(uint8_t**)s->pixels + j * s->pitch;
+            }
+
+            jo_gif_frame(&gif, *gifImage, 10, true, 0x00, 0xFF, 0x00);
+
+            free(gifImage);
+
+            SDL_FreeSurface(s);
+        }
+
+        jo_gif_end(&gif);
+
+}
 
     void SpriteGroup::destroy()
     {

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -18,7 +18,11 @@
 #include <misc/savePNG.h>
 #include <misc/stringops.h>
 
+// clang-format off
+#include <misc/disablewarn.h>
 #include "../../extern/jo_gif/jo_gif.cpp"
+#include <misc/enablewarn.h>
+// clang-format on
 
 /*#define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
@@ -843,7 +847,7 @@ namespace Render
             uint8_t** gifImage = (uint8_t**)malloc(s->h * sizeof(uint8_t*));
 
             for (int j = 0; j < s->h; j++)
-            {   
+            {
                 gifImage[j] = (uint8_t*)(uint8_t**)s->pixels + j * s->pitch;
             }
 
@@ -855,8 +859,7 @@ namespace Render
         }
 
         jo_gif_end(&gif);
-
-}
+    }
 
     void SpriteGroup::destroy()
     {

--- a/extern/jo_gif/jo_gif.cpp
+++ b/extern/jo_gif/jo_gif.cpp
@@ -1,0 +1,299 @@
+// modified version of https://www.jonolick.com/home/gif-writer
+/* public domain, Simple, Minimalistic GIF writer - http://jonolick.com
+ *
+ * Quick Notes:
+ * 	Supports only 4 component input, alpha is used. (RGBA)
+ *
+ * Latest revisions:
+ *      modified version (2019) 
+ * 	1.00 (2015-11-03) initial release
+ *
+ * Basic usage:
+ *	char *frame = new char[128*128*4]; // 4 component. RGBA format
+ *	jo_gif_t gif = jo_gif_start("foo.gif", 128, 128, 0, 32);
+ *	jo_gif_frame(&gif, frame, 4, false); // frame 1
+ *	jo_gif_frame(&gif, frame, 4, false); // frame 2
+ *	jo_gif_frame(&gif, frame, 4, false); // frame 3, ...
+ *	jo_gif_end(&gif);
+ * */
+
+#ifndef JO_INCLUDE_GIF_H
+#define JO_INCLUDE_GIF_H
+
+#include <stdio.h>
+
+// To get a header file for this, either cut and paste the header,
+// or create jo_gif.h, #define JO_GIF_HEADER_FILE_ONLY, and
+// then include jo_gif.cpp from it.
+
+typedef struct {
+	FILE *fp;
+	unsigned char palette[0x300];
+	short width, height, repeat;
+	int numColors, palSize;
+	int frame;
+} jo_gif_t;
+
+// width/height	| the same for every frame
+// repeat       | 0 = loop forever, 1 = loop once, etc...
+// palSize	| must be power of 2 - 1. so, 255 not 256.
+extern jo_gif_t jo_gif_start(const char *filename, short width, short height, short repeat, int palSize);
+
+// gif		| the state (returned from jo_gif_start)
+// rgba         | the pixels
+// delayCsec    | amount of time in between frames (in centiseconds)
+// localPalette | true if you want a unique palette generated for this frame (does not effect future frames)
+// tc_r         | red value for the color to be used as transparency
+// tc_g         | green value for the color to be used as transparency
+// tc_b         | blue value for the color to be used as transparency
+extern void jo_gif_frame(jo_gif_t *gif, unsigned char *rgba, short delayCsec, bool localPalette, unsigned char tc_r, unsigned char tc_g, unsigned char tc_b);
+
+// gif          | the state (returned from jo_gif_start)
+extern void jo_gif_end(jo_gif_t *gif);
+
+#endif
+
+#ifndef JO_GIF_HEADER_FILE_ONLY
+
+#if defined(_MSC_VER) && _MSC_VER >= 0x1400
+#define _CRT_SECURE_NO_WARNINGS // suppress warnings about fopen()
+#endif
+
+#include <stdlib.h>
+#include <memory.h>
+#include <math.h>
+
+bool in_palette(unsigned char *palette, int pal_size, unsigned char *color) {
+    for (int i = 0; i < pal_size; i++) {
+        if (palette[i * 3 + 0] == color[0] &&
+            palette[i * 3 + 1] == color[1] &&
+            palette[i * 3 + 2] == color[2]) {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+int get_index(unsigned char *palette, int pal_size, unsigned char *color) {
+    for (int i = 0; i < pal_size; i++) {
+        if (palette[i*3+0] == color[0] &&
+            palette[i*3+1] == color[1] &&
+            palette[i*3+2] == color[2]) {
+            return i;
+        }
+    }
+
+    printf("index not found for color: %x|%x|%x\n", color[0], color[1], color[2]);
+    printf("using transparent index as a fallback\n");
+    return 0;
+}
+
+static void index_pixels(unsigned char *rgba, int img_size, unsigned char *palette, int pal_size, unsigned char *indexedPixels) {
+    for(int k = 0; k < img_size*4; k+=4) {
+        // if pixel is fully transparent, assign it 0 (transparency index)
+        if (rgba[k+3] == 0x00) {
+            indexedPixels[k/4] = 0;
+        }
+        
+        // else assign its palette index
+        else {
+            unsigned char color[3] = {rgba[k+0], rgba[k+1], rgba[k+2]};
+            int index = get_index(palette, pal_size, color);
+            indexedPixels[k/4] = index;
+        }
+    }
+}
+
+static void make_palette(int img_size, unsigned char *rgba, unsigned char *palette, int final_pal_size, unsigned char *trans_color) {
+    // set first color of palette as transparent
+    palette[0] = trans_color[0];
+    palette[1] = trans_color[1];
+    palette[2] = trans_color[2];
+    
+    // walk through image and assign all colors to palette
+    int pal_size = 1;
+    for(int k = 0; k < img_size*4; k+=4) {
+        unsigned char color[3] = {rgba[k+0], rgba[k+1], rgba[k+2]};
+        if (!in_palette(palette, pal_size, color)) {
+            palette[pal_size * 3 + 0] = color[0];
+            palette[pal_size * 3 + 1] = color[1];
+            palette[pal_size * 3 + 2] = color[2];
+            pal_size++;
+        }
+    }
+    
+    // fill any leftover spots in the palette with black
+    for (; pal_size < final_pal_size; pal_size++) {
+        palette[pal_size * 3 + 0] = 0x00;
+        palette[pal_size * 3 + 1] = 0x00;
+        palette[pal_size * 3 + 2] = 0x00;
+    }
+}
+
+typedef struct {
+	FILE *fp;
+	int numBits;
+	unsigned char buf[256];
+	unsigned char idx;
+	unsigned tmp;
+	int outBits;
+	int curBits;
+} jo_gif_lzw_t;
+
+static void jo_gif_lzw_write(jo_gif_lzw_t *s, int code) {
+	s->outBits |= code << s->curBits;
+	s->curBits += s->numBits;
+	while(s->curBits >= 8) {
+		s->buf[s->idx++] = s->outBits & 255;
+		s->outBits >>= 8;
+		s->curBits -= 8;
+		if (s->idx >= 255) {
+			putc(s->idx, s->fp);
+			fwrite(s->buf, s->idx, 1, s->fp);
+			s->idx = 0;
+		}
+	}
+}
+
+static void jo_gif_lzw_encode(unsigned char *in, int len, FILE *fp) {
+	jo_gif_lzw_t state = {fp, 9};
+	int maxcode = 511;
+
+	// Note: 30k stack space for dictionary =|
+	const int hashSize = 5003;
+	short codetab[hashSize];
+	int hashTbl[hashSize];
+	memset(hashTbl, 0xFF, sizeof(hashTbl));
+
+	jo_gif_lzw_write(&state, 0x100);
+
+	int free_ent = 0x102;
+	int ent = *in++;
+CONTINUE:
+	while (--len) {
+		int c = *in++;
+		int fcode = (c << 12) + ent;
+		int key = (c << 4) ^ ent; // xor hashing
+		while(hashTbl[key] >= 0) {
+			if(hashTbl[key] == fcode) {
+				ent = codetab[key];
+				goto CONTINUE;
+			}
+			++key;
+			key = key >= hashSize ? key - hashSize : key;
+		}
+		jo_gif_lzw_write(&state, ent);
+		ent = c;
+		if(free_ent < 4096) {
+			if(free_ent > maxcode) {
+				++state.numBits;
+				if(state.numBits == 12) {
+					maxcode = 4096;
+				} else {
+					maxcode = (1<<state.numBits)-1;
+				}
+			}
+			codetab[key] = free_ent++;
+			hashTbl[key] = fcode;
+		} else {
+			memset(hashTbl, 0xFF, sizeof(hashTbl));
+			free_ent = 0x102;
+			jo_gif_lzw_write(&state, 0x100);
+			state.numBits = 9;
+			maxcode = 511;
+		}
+	}
+	jo_gif_lzw_write(&state, ent);
+	jo_gif_lzw_write(&state, 0x101);
+	jo_gif_lzw_write(&state, 0);
+	if(state.idx) {
+		putc(state.idx, fp);
+		fwrite(state.buf, state.idx, 1, fp);
+	}
+}
+
+jo_gif_t jo_gif_start(const char *filename, short width, short height, short repeat, int numColors) {
+	numColors = numColors > 255 ? 255 : numColors < 2 ? 2 : numColors;
+	jo_gif_t gif = {};
+	gif.width = width;
+	gif.height = height;
+	gif.repeat = repeat;
+	gif.numColors = numColors;
+	gif.palSize = log2(numColors);
+
+	gif.fp = fopen(filename, "wb");
+	if(!gif.fp) {
+		printf("Error: Could not WriteGif to %s\n", filename);
+		return gif;
+	}
+
+	fwrite("GIF89a", 6, 1, gif.fp);
+	// Logical Screen Descriptor
+	fwrite(&gif.width, 2, 1, gif.fp);
+	fwrite(&gif.height, 2, 1, gif.fp);
+	putc(0xF0 | gif.palSize, gif.fp);
+	fwrite("\x00\x00", 2, 1, gif.fp); // bg color index (unused), aspect ratio
+	return gif;
+}
+
+void jo_gif_frame(jo_gif_t *gif, unsigned char * rgba, short delayCsec, bool localPalette, unsigned char tc_r, unsigned char tc_g, unsigned char tc_b) {
+	if(!gif->fp) {
+		return;
+	}
+        
+        unsigned char trans_color[3] = {tc_r, tc_g, tc_b};
+        
+	short width = gif->width;
+	short height = gif->height;
+	int img_size = width * height;
+        int pal_size = gif->numColors+1;
+
+	unsigned char localPalTbl[0x300];
+	unsigned char *palette = gif->frame == 0 || !localPalette ? gif->palette : localPalTbl;
+	if(gif->frame == 0 || localPalette) {
+                make_palette(img_size, rgba, palette, pal_size, trans_color);
+	}
+
+	unsigned char *indexedPixels = (unsigned char *)malloc(img_size);
+        index_pixels(rgba, img_size, palette, pal_size, indexedPixels);
+
+	if(gif->frame == 0) {
+		// Global Color Table
+		fwrite(palette, 3*(1<<(gif->palSize+1)), 1, gif->fp);
+		if(gif->repeat >= 0) {
+			// Netscape Extension
+			fwrite("\x21\xff\x0bNETSCAPE2.0\x03\x01", 16, 1, gif->fp);
+			fwrite(&gif->repeat, 2, 1, gif->fp); // loop count (extra iterations, 0=repeat forever)
+			putc(0, gif->fp); // block terminator
+		}
+	}
+	// Graphic Control Extension
+	fwrite("\x21\xf9\x04\x09", 4, 1, gif->fp); // last byte sets disposal method to replace and transparency on
+	fwrite(&delayCsec, 2, 1, gif->fp); // delayCsec x 1/100 sec
+	fwrite("\x00\x00", 2, 1, gif->fp); // transparent color index (first byte)
+	// Image Descriptor
+	fwrite("\x2c\x00\x00\x00\x00", 5, 1, gif->fp); // header, x,y
+	fwrite(&width, 2, 1, gif->fp);
+	fwrite(&height, 2, 1, gif->fp);
+	if (gif->frame == 0 || !localPalette) {
+		putc(0, gif->fp);
+	} else {
+		putc(0x80|gif->palSize, gif->fp );
+		fwrite(palette, 3*(1<<(gif->palSize+1)), 1, gif->fp);
+	}
+	putc(8, gif->fp); // block terminator
+	jo_gif_lzw_encode(indexedPixels, img_size, gif->fp);
+	putc(0, gif->fp); // block terminator
+	++gif->frame;
+	free(indexedPixels);
+}
+
+void jo_gif_end(jo_gif_t *gif) {
+	if(!gif->fp) {
+		return;
+	}
+	putc(0x3b, gif->fp); // gif trailer
+	fclose(gif->fp);
+}
+#endif


### PR DESCRIPTION
Since a lot of CEL/CL2's are animations I have added an option to celview to save as an animated gif.  Transparency is supported and the resulting gifs open properly in gimp.  In all the tests I did there was never a problem with palette size -- thankfully diablo doesn't seem to use all 256 colors + transparency in each CEL/CL2.  The end filesize is not as small as it could be because a full 256 palette is generated for each frame, but since we're dealing with such low resolution I don't think it's a big problem.

I'm not sure if I should have modified cmake files to include the new library (jo_gif.cpp), but it compiles fine for me.  So, let me know if this needs any changes.

EDIT: I see travis is set to treat warnings as errors.  jo_gif.cpp started off with the warnings about the initializer list, but since it would compile on my system I just left it.  If you want I'll see if I can get rid of them.

EDIT2: I tried to fix the travis formatting issue with:

    curl https://termbin.com/t4hrn > /tmp/fa_format_diff.patch && git apply /tmp/fa_format_diff.patch

but first I got a certificate error and then when I connected with an insecure connection it couldn't find components/render/sdl2backend.cpp.  Any help would be appreciated.