### PR TITLE
Update player graphics when equipment changed

### DIFF
--- a/apps/freeablo/faworld/inventory.cpp
+++ b/apps/freeablo/faworld/inventory.cpp
@@ -214,6 +214,8 @@ namespace FAWorld
         }
 
         mInventoryBox.get(x, y).mIsReal = true;
+        inventoryChanged();
+
         return PlaceItemResult{PlaceItemResult::Type::Success, {}};
     }
 
@@ -272,6 +274,8 @@ namespace FAWorld
             for (int xLocal = result.getCornerCoords().first; xLocal < result.getCornerCoords().first + itemSize.x; ++xLocal)
                 mInventoryBox.get(xLocal, yLocal) = {};
 
+        inventoryChanged();
+
         return result;
     }
 
@@ -290,6 +294,15 @@ namespace FAWorld
                                    const boost::optional<EquipTarget>& newTargetArg)
         : NeedsToBeReplaced(std::move(NeedsToBeReplacedArg)), NeedsToBeReturned(std::move(NeedsToBeReturnedArg)), newTarget(newTargetArg)
     {
+    }
+
+    CharacterInventory::CharacterInventory()
+    {
+        BasicInventory* equipableInventories[] = { &mBelt, &mHead, &mBody, &mLeftRing, &mRightRing, &mAmulet, &mLeftHand, &mRightHand };
+        for (auto inv : equipableInventories)
+        {
+            inv->inventoryChanged.connect([this]() { equipChanged(); });
+        }
     }
 
     void CharacterInventory::save(FASaveGame::GameSaver& saver)
@@ -339,7 +352,6 @@ namespace FAWorld
         {
             release_assert(mLeftHand.autoPlaceItem(item));
             release_assert(mRightHand.autoPlaceItem(item));
-            equipChanged();
             return true;
         }
 
@@ -347,7 +359,6 @@ namespace FAWorld
         if (item.getEquipLoc() == ItemEquipType::oneHanded && item.getClass() == ItemClass::weapon && leftHand.isEmpty())
         {
             mLeftHand.autoPlaceItem(item);
-            equipChanged();
             return true;
         }
 

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -69,6 +69,8 @@ namespace FAWorld
         const_iterator begin() const { return mInventoryBox.begin(); }
         const_iterator end() const { return mInventoryBox.end(); }
 
+        boost::signals2::signal<void()> inventoryChanged;
+
     private:
         Misc::Array2D<Item> mInventoryBox;
         bool mTreatAllItemsAs1by1 = false;
@@ -78,6 +80,7 @@ namespace FAWorld
     class CharacterInventory
     {
     public:
+        CharacterInventory();
         void save(FASaveGame::GameSaver& saver);
         void load(FASaveGame::GameLoader& loader);
 


### PR DESCRIPTION
Most the hard work was already done, just connected it up.
Can be a slight lag since the other graphics files aren't preloaded.

e.g. Mace, armour and shield:
![untitled](https://user-images.githubusercontent.com/8636545/50888157-e3eb3c00-1459-11e9-8f01-a84f20015448.png)
