### PR TITLE
Play inventory sounds and update player graphics

### DIFF
--- a/apps/freeablo/faworld/inventory.cpp
+++ b/apps/freeablo/faworld/inventory.cpp
@@ -298,8 +298,8 @@ namespace FAWorld
 
     CharacterInventory::CharacterInventory()
     {
-       for (auto inv : mInventoryTypes)
-           inv.second.mInventoryChanged.connect([this, inv](Item const& removed, Item const& added) { mInventoryChanged(inv.first, removed, added); });
+        for (auto inv : mInventoryTypes)
+            inv.second.mInventoryChanged.connect([this, inv](Item const& removed, Item const& added) { mInventoryChanged(inv.first, removed, added); });
     }
 
     void CharacterInventory::save(FASaveGame::GameSaver& saver)
@@ -403,8 +403,8 @@ namespace FAWorld
 
     BasicInventory& CharacterInventory::getInvMutable(EquipTargetType type)
     {
-        auto it = std::find_if(mInventoryTypes.begin(), mInventoryTypes.end(),
-            [type](const std::pair<EquipTargetType, BasicInventory&> & m) -> bool { return m.first == type; });
+        auto it = std::find_if(
+            mInventoryTypes.begin(), mInventoryTypes.end(), [type](const std::pair<EquipTargetType, BasicInventory&>& m) -> bool { return m.first == type; });
         return it->second;
     }
 

--- a/apps/freeablo/faworld/inventory.cpp
+++ b/apps/freeablo/faworld/inventory.cpp
@@ -298,11 +298,9 @@ namespace FAWorld
 
     CharacterInventory::CharacterInventory()
     {
-        BasicInventory* inventories[] = { &mMainInventory, &mBelt, &mHead, &mBody, &mLeftRing, &mRightRing, &mAmulet, &mLeftHand, &mRightHand };
+        BasicInventory* inventories[] = {&mMainInventory, &mBelt, &mHead, &mBody, &mLeftRing, &mRightRing, &mAmulet, &mLeftHand, &mRightHand};
         for (auto inv : inventories)
-        {
             inv->inventoryChanged.connect([this, inv](Item const& removed, Item const& added) { inventoryChanged(*inv, removed, added); });
-        }
     }
 
     void CharacterInventory::save(FASaveGame::GameSaver& saver)

--- a/apps/freeablo/faworld/inventory.cpp
+++ b/apps/freeablo/faworld/inventory.cpp
@@ -301,6 +301,7 @@ namespace FAWorld
         BasicInventory* inventories[] = {&mMainInventory, &mBelt, &mHead, &mBody, &mLeftRing, &mRightRing, &mAmulet, &mLeftHand, &mRightHand};
         for (auto inv : inventories)
             inv->inventoryChanged.connect([this, inv](Item const& removed, Item const& added) { inventoryChanged(*inv, removed, added); });
+        mCursorHeld.inventoryChanged.connect([this](Item const& removed, Item const& added) { cursorItemChanged(removed, added); });
     }
 
     void CharacterInventory::save(FASaveGame::GameSaver& saver)

--- a/apps/freeablo/faworld/inventory.cpp
+++ b/apps/freeablo/faworld/inventory.cpp
@@ -298,10 +298,8 @@ namespace FAWorld
 
     CharacterInventory::CharacterInventory()
     {
-        BasicInventory* inventories[] = {&mMainInventory, &mBelt, &mHead, &mBody, &mLeftRing, &mRightRing, &mAmulet, &mLeftHand, &mRightHand};
-        for (auto inv : inventories)
-            inv->inventoryChanged.connect([this, inv](Item const& removed, Item const& added) { inventoryChanged(*inv, removed, added); });
-        mCursorHeld.inventoryChanged.connect([this](Item const& removed, Item const& added) { cursorItemChanged(removed, added); });
+       for (auto inv : mInventoryTypes)
+           inv.second.inventoryChanged.connect([this, inv](Item const& removed, Item const& added) { inventoryChanged(inv.first, removed, added); });
     }
 
     void CharacterInventory::save(FASaveGame::GameSaver& saver)
@@ -405,31 +403,9 @@ namespace FAWorld
 
     BasicInventory& CharacterInventory::getInvMutable(EquipTargetType type)
     {
-        switch (type)
-        {
-            case EquipTargetType::inventory:
-                return mMainInventory;
-            case EquipTargetType::belt:
-                return mBelt;
-            case EquipTargetType::head:
-                return mHead;
-            case EquipTargetType::body:
-                return mBody;
-            case EquipTargetType::leftRing:
-                return mLeftRing;
-            case EquipTargetType::rightRing:
-                return mRightRing;
-            case EquipTargetType::leftHand:
-                return mLeftHand;
-            case EquipTargetType::rightHand:
-                return mRightHand;
-            case EquipTargetType::amulet:
-                return mAmulet;
-            case EquipTargetType::cursor:
-                return mCursorHeld;
-        }
-
-        invalid_enum(EquipTargetType, type);
+        auto it = std::find_if(mInventoryTypes.begin(), mInventoryTypes.end(),
+            [type](const std::pair<EquipTargetType, BasicInventory&> & m) -> bool { return m.first == type; });
+        return it->second;
     }
 
     void CharacterInventory::slotClicked(const EquipTarget& slot)

--- a/apps/freeablo/faworld/inventory.cpp
+++ b/apps/freeablo/faworld/inventory.cpp
@@ -399,14 +399,9 @@ namespace FAWorld
         mCursorHeld.placeItem(item, 0, 0).succeeded();
     }
 
-    const BasicInventory& CharacterInventory::getInv(EquipTargetType type) const { return const_cast<CharacterInventory*>(this)->getInvMutable(type); }
+    const BasicInventory& CharacterInventory::getInv(EquipTargetType type) const { return mInventoryTypes.at(type); }
 
-    BasicInventory& CharacterInventory::getInvMutable(EquipTargetType type)
-    {
-        auto it = std::find_if(
-            mInventoryTypes.begin(), mInventoryTypes.end(), [type](const std::pair<EquipTargetType, BasicInventory&>& m) -> bool { return m.first == type; });
-        return it->second;
-    }
+    BasicInventory& CharacterInventory::getInvMutable(EquipTargetType type) { return mInventoryTypes.at(type); }
 
     void CharacterInventory::slotClicked(const EquipTarget& slot)
     {

--- a/apps/freeablo/faworld/inventory.cpp
+++ b/apps/freeablo/faworld/inventory.cpp
@@ -214,7 +214,7 @@ namespace FAWorld
         }
 
         mInventoryBox.get(x, y).mIsReal = true;
-        inventoryChanged(Item(), item);
+        mInventoryChanged(Item(), item);
 
         return PlaceItemResult{PlaceItemResult::Type::Success, {}};
     }
@@ -274,7 +274,7 @@ namespace FAWorld
             for (int xLocal = result.getCornerCoords().first; xLocal < result.getCornerCoords().first + itemSize.x; ++xLocal)
                 mInventoryBox.get(xLocal, yLocal) = {};
 
-        inventoryChanged(result, Item());
+        mInventoryChanged(result, Item());
 
         return result;
     }
@@ -299,7 +299,7 @@ namespace FAWorld
     CharacterInventory::CharacterInventory()
     {
        for (auto inv : mInventoryTypes)
-           inv.second.inventoryChanged.connect([this, inv](Item const& removed, Item const& added) { inventoryChanged(inv.first, removed, added); });
+           inv.second.mInventoryChanged.connect([this, inv](Item const& removed, Item const& added) { mInventoryChanged(inv.first, removed, added); });
     }
 
     void CharacterInventory::save(FASaveGame::GameSaver& saver)

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -136,15 +136,15 @@ namespace FAWorld
         BasicInventory mRightHand = BasicInventory(1, 1, true);
         BasicInventory mCursorHeld = BasicInventory(1, 1, true);
 
-        const std::vector<std::pair<EquipTargetType, BasicInventory&>> mInventoryTypes = {{EquipTargetType::inventory, mMainInventory},
-                                                                                          {EquipTargetType::belt, mBelt},
-                                                                                          {EquipTargetType::head, mHead},
-                                                                                          {EquipTargetType::body, mBody},
-                                                                                          {EquipTargetType::leftRing, mLeftRing},
-                                                                                          {EquipTargetType::rightRing, mRightRing},
-                                                                                          {EquipTargetType::leftHand, mLeftHand},
-                                                                                          {EquipTargetType::rightHand, mRightHand},
-                                                                                          {EquipTargetType::amulet, mAmulet},
-                                                                                          {EquipTargetType::cursor, mCursorHeld}};
+        std::map<EquipTargetType, BasicInventory&> mInventoryTypes = {{EquipTargetType::inventory, mMainInventory},
+                                                                      {EquipTargetType::belt, mBelt},
+                                                                      {EquipTargetType::head, mHead},
+                                                                      {EquipTargetType::body, mBody},
+                                                                      {EquipTargetType::leftRing, mLeftRing},
+                                                                      {EquipTargetType::rightRing, mRightRing},
+                                                                      {EquipTargetType::leftHand, mLeftHand},
+                                                                      {EquipTargetType::rightHand, mRightHand},
+                                                                      {EquipTargetType::amulet, mAmulet},
+                                                                      {EquipTargetType::cursor, mCursorHeld}};
     };
 }

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -69,6 +69,8 @@ namespace FAWorld
         const_iterator begin() const { return mInventoryBox.begin(); }
         const_iterator end() const { return mInventoryBox.end(); }
 
+        boost::signals2::signal<void (Item const& removed, Item const& added)> inventoryChanged;
+
     private:
         Misc::Array2D<Item> mInventoryBox;
         bool mTreatAllItemsAs1by1 = false;
@@ -78,6 +80,7 @@ namespace FAWorld
     class CharacterInventory
     {
     public:
+        CharacterInventory();
         void save(FASaveGame::GameSaver& saver);
         void load(FASaveGame::GameLoader& loader);
 
@@ -115,7 +118,7 @@ namespace FAWorld
 
     public:
         // This is not serialised - it should be reconnected by other means
-        boost::signals2::signal<void()> equipChanged;
+        boost::signals2::signal<void (BasicInventory const& inventory, Item const& removed, Item const& added)> inventoryChanged;
 
     private:
         static constexpr int32_t inventoryWidth = 10;

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -136,16 +136,15 @@ namespace FAWorld
         BasicInventory mRightHand = BasicInventory(1, 1, true);
         BasicInventory mCursorHeld = BasicInventory(1, 1, true);
 
-        const std::vector<std::pair<EquipTargetType, BasicInventory&>> mInventoryTypes = {
-            { EquipTargetType::inventory, mMainInventory },
-            { EquipTargetType::belt, mBelt },
-            { EquipTargetType::head, mHead },
-            { EquipTargetType::body, mBody },
-            { EquipTargetType::leftRing, mLeftRing },
-            { EquipTargetType::rightRing, mRightRing },
-            { EquipTargetType::leftHand, mLeftHand },
-            { EquipTargetType::rightHand, mRightHand },
-            { EquipTargetType::amulet, mAmulet },
-            { EquipTargetType::cursor, mCursorHeld } };
+        const std::vector<std::pair<EquipTargetType, BasicInventory&>> mInventoryTypes = {{EquipTargetType::inventory, mMainInventory},
+                                                                                          {EquipTargetType::belt, mBelt},
+                                                                                          {EquipTargetType::head, mHead},
+                                                                                          {EquipTargetType::body, mBody},
+                                                                                          {EquipTargetType::leftRing, mLeftRing},
+                                                                                          {EquipTargetType::rightRing, mRightRing},
+                                                                                          {EquipTargetType::leftHand, mLeftHand},
+                                                                                          {EquipTargetType::rightHand, mRightHand},
+                                                                                          {EquipTargetType::amulet, mAmulet},
+                                                                                          {EquipTargetType::cursor, mCursorHeld}};
     };
 }

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -69,7 +69,7 @@ namespace FAWorld
         const_iterator begin() const { return mInventoryBox.begin(); }
         const_iterator end() const { return mInventoryBox.end(); }
 
-        boost::signals2::signal<void (Item const& removed, Item const& added)> inventoryChanged;
+        boost::signals2::signal<void(Item const& removed, Item const& added)> inventoryChanged;
 
     private:
         Misc::Array2D<Item> mInventoryBox;
@@ -118,7 +118,7 @@ namespace FAWorld
 
     public:
         // This is not serialised - it should be reconnected by other means
-        boost::signals2::signal<void (BasicInventory const& inventory, Item const& removed, Item const& added)> inventoryChanged;
+        boost::signals2::signal<void(BasicInventory const& inventory, Item const& removed, Item const& added)> inventoryChanged;
 
     private:
         static constexpr int32_t inventoryWidth = 10;

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -118,8 +118,7 @@ namespace FAWorld
 
     public:
         // This is not serialised - it should be reconnected by other means
-        boost::signals2::signal<void(BasicInventory const& inventory, Item const& removed, Item const& added)> inventoryChanged;
-        boost::signals2::signal<void(Item const& removed, Item const& added)> cursorItemChanged;
+        boost::signals2::signal<void(EquipTargetType inventoryType, Item const& removed, Item const& added)> inventoryChanged;
 
     private:
         static constexpr int32_t inventoryWidth = 10;
@@ -136,5 +135,17 @@ namespace FAWorld
         BasicInventory mLeftHand = BasicInventory(1, 1, true);
         BasicInventory mRightHand = BasicInventory(1, 1, true);
         BasicInventory mCursorHeld = BasicInventory(1, 1, true);
+
+        const std::vector<std::pair<EquipTargetType, BasicInventory&>> mInventoryTypes = {
+            { EquipTargetType::inventory, mMainInventory },
+            { EquipTargetType::belt, mBelt },
+            { EquipTargetType::head, mHead },
+            { EquipTargetType::body, mBody },
+            { EquipTargetType::leftRing, mLeftRing },
+            { EquipTargetType::rightRing, mRightRing },
+            { EquipTargetType::leftHand, mLeftHand },
+            { EquipTargetType::rightHand, mRightHand },
+            { EquipTargetType::amulet, mAmulet },
+            { EquipTargetType::cursor, mCursorHeld } };
     };
 }

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -119,6 +119,7 @@ namespace FAWorld
     public:
         // This is not serialised - it should be reconnected by other means
         boost::signals2::signal<void(BasicInventory const& inventory, Item const& removed, Item const& added)> inventoryChanged;
+        boost::signals2::signal<void(Item const& removed, Item const& added)> cursorItemChanged;
 
     private:
         static constexpr int32_t inventoryWidth = 10;

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -69,7 +69,7 @@ namespace FAWorld
         const_iterator begin() const { return mInventoryBox.begin(); }
         const_iterator end() const { return mInventoryBox.end(); }
 
-        boost::signals2::signal<void(Item const& removed, Item const& added)> inventoryChanged;
+        boost::signals2::signal<void(Item const& removed, Item const& added)> mInventoryChanged;
 
     private:
         Misc::Array2D<Item> mInventoryBox;
@@ -118,7 +118,7 @@ namespace FAWorld
 
     public:
         // This is not serialised - it should be reconnected by other means
-        boost::signals2::signal<void(EquipTargetType inventoryType, Item const& removed, Item const& added)> inventoryChanged;
+        boost::signals2::signal<void(EquipTargetType inventoryType, Item const& removed, Item const& added)> mInventoryChanged;
 
     private:
         static constexpr int32_t inventoryWidth = 10;

--- a/apps/freeablo/faworld/item.cpp
+++ b/apps/freeablo/faworld/item.cpp
@@ -180,40 +180,12 @@ namespace FAWorld
 
     std::string Item::getFlipSoundPath() const
     {
-        // TODO: add book, pot, scroll
-        switch (getType())
-        {
-            case ItemType::misc:
-                return "";
-            case ItemType::sword:
-                return "sfx/items/flipswor.wav";
-            case ItemType::axe:
-                return "sfx/items/flipaxe.wav";
-            case ItemType::bow:
-                return "sfx/items/flipbow.wav";
-            case ItemType::mace:
-                return "sfx/items/flipswor.wav"; // TODO: check
-            case ItemType::shield:
-                return "sfx/items/flipshld.wav";
-            case ItemType::lightArmor:
-                return "sfx/items/fliplarm.wav";
-            case ItemType::helm:
-                return "sfx/items/flipcap.wav";
-            case ItemType::mediumArmor:
-                return "sfx/items/fliplarm.wav"; // TODO: check
-            case ItemType::heavyArmor:
-                return "sfx/items/flipharm.wav";
-            case ItemType::staff:
-                return "sfx/items/flipstaf.wav";
-            case ItemType::gold:
-                return "sfx/items/gold.wav"; // also gold1.cel
-            case ItemType::ring:
-            case ItemType::amulet:
-                return "sfx/items/flipring.wav";
-            case ItemType::none:
-                break;
-        }
-        return "";
+        return base().dropItemSoundPath;
+    }
+
+    std::string Item::getInvPlaceSoundPath() const
+    {
+        return base().invPlaceItemSoundPath;
     }
 
     FARender::FASpriteGroup* Item::getFlipSpriteGroup() { return FARender::Renderer::get()->loadImage(base().dropItemGraphicsPath); }

--- a/apps/freeablo/faworld/item.cpp
+++ b/apps/freeablo/faworld/item.cpp
@@ -178,15 +178,9 @@ namespace FAWorld
 
     Item::~Item() {}
 
-    std::string Item::getFlipSoundPath() const
-    {
-        return base().dropItemSoundPath;
-    }
+    std::string Item::getFlipSoundPath() const { return base().dropItemSoundPath; }
 
-    std::string Item::getInvPlaceSoundPath() const
-    {
-        return base().invPlaceItemSoundPath;
-    }
+    std::string Item::getInvPlaceSoundPath() const { return base().invPlaceItemSoundPath; }
 
     FARender::FASpriteGroup* Item::getFlipSpriteGroup() { return FARender::Renderer::get()->loadImage(base().dropItemGraphicsPath); }
 

--- a/apps/freeablo/faworld/item.h
+++ b/apps/freeablo/faworld/item.h
@@ -70,6 +70,7 @@ namespace FAWorld
         std::pair<uint8_t, uint8_t> getCornerCoords() const;
         bool isEmpty() const { return mEmpty; }
         std::string getFlipSoundPath() const;
+        std::string getInvPlaceSoundPath() const;
         FARender::FASpriteGroup* getFlipSpriteGroup();
         bool isBeltEquippable() const;
         int32_t getMaxCount() const;

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -54,7 +54,7 @@ namespace FAWorld
     void Player::initCommon()
     {
         mWorld.registerPlayer(this);
-        mInventory.inventoryChanged.connect([this](EquipTargetType inventoryType, Item const& removed, Item const& added) {
+        mInventory.mInventoryChanged.connect([this](EquipTargetType inventoryType, Item const& removed, Item const& added) {
             (void)removed;
 
             // Update player graphics.

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -58,13 +58,21 @@ namespace FAWorld
             (void)inventory;
             (void)removed;
 
+            // Update player graphics.
             updateSprites();
 
-            // Play inventory grab/place sound.
-            std::string soundPath = "sfx/items/invgrab.wav";
             if (!added.isEmpty())
-                soundPath = added.getInvPlaceSoundPath();
-            Engine::ThreadManager::get()->playSound(soundPath);
+            {
+                // Play inventory place sound.
+                std::string soundPath = added.getInvPlaceSoundPath();
+                Engine::ThreadManager::get()->playSound(soundPath);
+            }
+        });
+        mInventory.cursorItemChanged.connect([](Item const& removed, Item const& added) {
+            (void)removed;
+            if (!added.isEmpty())
+                // Play cursor grab sound.
+                Engine::ThreadManager::get()->playSound("sfx/items/invgrab.wav");
         });
         mMoveHandler.positionReached.connect(positionReached);
     }

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -54,7 +54,20 @@ namespace FAWorld
     void Player::initCommon()
     {
         mWorld.registerPlayer(this);
-        mInventory.equipChanged.connect([this]() { updateSprites(); });
+        mInventory.inventoryChanged.connect([this](BasicInventory const& inventory, Item const& removed, Item const& added) {
+            (void)inventory;
+            (void)removed;
+
+            updateSprites();
+
+            // Play inventory grab/place sound.
+            std::string soundPath = "sfx/items/invgrab.wav";
+            if (!added.isEmpty())
+            {
+                soundPath = added.getInvPlaceSoundPath();
+            }
+            Engine::ThreadManager::get()->playSound(soundPath);
+        });
         mMoveHandler.positionReached.connect(positionReached);
     }
 

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -54,27 +54,39 @@ namespace FAWorld
     void Player::initCommon()
     {
         mWorld.registerPlayer(this);
-        mInventory.inventoryChanged.connect([this](BasicInventory const& inventory, Item const& removed, Item const& added) {
-            (void)inventory;
+        mInventory.inventoryChanged.connect([this](EquipTargetType inventoryType, Item const& removed, Item const& added) {
             (void)removed;
 
             // Update player graphics.
             updateSprites();
 
+            switch (inventoryType)
+            {
+                case EquipTargetType::body:
+                case EquipTargetType::leftHand:
+                case EquipTargetType::rightHand:
+                    // Update player graphics.
+                    updateSprites();
+                    break;
+                default:
+                    break;
+            }
+
             if (!added.isEmpty())
             {
-                // Play inventory place sound.
-                std::string soundPath = added.getInvPlaceSoundPath();
-                Engine::ThreadManager::get()->playSound(soundPath);
+                // Play inventory place/grab sound.
+                switch (inventoryType)
+                {
+                    case EquipTargetType::cursor:
+                        Engine::ThreadManager::get()->playSound("sfx/items/invgrab.wav");
+                        break;
+                    default:
+                        std::string soundPath = added.getInvPlaceSoundPath();
+                        Engine::ThreadManager::get()->playSound(soundPath);
+                        break;
+                }
             }
         });
-        mInventory.cursorItemChanged.connect([](Item const& removed, Item const& added) {
-            (void)removed;
-            if (!added.isEmpty())
-                // Play cursor grab sound.
-                Engine::ThreadManager::get()->playSound("sfx/items/invgrab.wav");
-        });
-        mMoveHandler.positionReached.connect(positionReached);
     }
 
     void Player::setPlayerClass(PlayerClass playerClass)

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -72,7 +72,7 @@ namespace FAWorld
                     break;
             }
 
-            if (!added.isEmpty() && mPlayerInitialised)
+            if (!added.isEmpty() && mPlayerInitialised && this == mWorld.getCurrentPlayer())
             {
                 // Play inventory place/grab sound.
                 switch (inventoryType)

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -63,9 +63,7 @@ namespace FAWorld
             // Play inventory grab/place sound.
             std::string soundPath = "sfx/items/invgrab.wav";
             if (!added.isEmpty())
-            {
                 soundPath = added.getInvPlaceSoundPath();
-            }
             Engine::ThreadManager::get()->playSound(soundPath);
         });
         mMoveHandler.positionReached.connect(positionReached);

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -131,6 +131,8 @@ namespace FAWorld
 
     void Player::save(FASaveGame::GameSaver& saver)
     {
+        release_assert(mPlayerInitialised);
+
         Serial::ScopedCategorySaver cat("Player", saver);
 
         Actor::save(saver);

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -72,7 +72,7 @@ namespace FAWorld
                     break;
             }
 
-            if (!added.isEmpty())
+            if (!added.isEmpty() && mPlayerInitialised)
             {
                 // Play inventory place/grab sound.
                 switch (inventoryType)
@@ -126,6 +126,7 @@ namespace FAWorld
         mPlayerClass = static_cast<PlayerClass>(loader.load<int32_t>());
         mPlayerStats = {loader};
         initCommon();
+        mPlayerInitialised = true;
     }
 
     void Player::save(FASaveGame::GameSaver& saver)

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -55,6 +55,8 @@ namespace FAWorld
         int getDamageBonus() const { /* placeholder */ return 0; }
         ItemBonus getItemBonus() const;
 
+        bool mPlayerInitialised = false;
+
     private:
         void init(const DiabloExe::CharacterStats& charStats);
         bool canTalkTo(Actor* actor);

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -55,6 +55,7 @@ namespace FAWorld
         int getDamageBonus() const { /* placeholder */ return 0; }
         ItemBonus getItemBonus() const;
 
+        // This isn't serialised as it must be set before saving can occur.
         bool mPlayerInitialised = false;
 
     private:

--- a/apps/freeablo/faworld/playerfactory.cpp
+++ b/apps/freeablo/faworld/playerfactory.cpp
@@ -23,6 +23,8 @@ namespace FAWorld
         else
             createSorcerer(player);
 
+        player->mPlayerInitialised = true;
+
         return player;
     }
 

--- a/components/diabloexe/baseitem.h
+++ b/components/diabloexe/baseitem.h
@@ -50,6 +50,8 @@ namespace DiabloExe
         int32_t invSizeY;
 
         std::string dropItemGraphicsPath;
+        std::string dropItemSoundPath;
+        std::string invPlaceItemSoundPath;
 
         std::string dump() const;
         BaseItem();

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -149,12 +149,12 @@ namespace DiabloExe
     void DiabloExe::loadDropGraphicsFilenames(FAIO::FAFileObject& exe, size_t codeOffset)
     {
         const uint64_t offset = mSettings->get<uint64_t>("ItemDropGraphics", "filenames");
-        itemDropGraphicsFilename.resize(35);
-        for (int i = 0; i < static_cast<int>(itemDropGraphicsFilename.size()); ++i)
+        mItemDropGraphicsFilename.resize(35);
+        for (int i = 0; i < static_cast<int>(mItemDropGraphicsFilename.size()); ++i)
         {
             exe.FAfseek(offset + i * 4, SEEK_SET);
             auto nameOffset = exe.read32();
-            itemDropGraphicsFilename[i] = exe.readCStringFromWin32Binary(nameOffset, codeOffset);
+            mItemDropGraphicsFilename[i] = exe.readCStringFromWin32Binary(nameOffset, codeOffset);
         }
     }
 
@@ -162,26 +162,26 @@ namespace DiabloExe
     {
         uint64_t offset = mSettings->get<uint64_t>("Sounds", "filenameTable");
         int32_t filenameTableSize = mSettings->get<int32_t>("Sounds", "filenameTableSize");
-        soundFilename.resize(filenameTableSize);
-        for (int i = 0; i < static_cast<int>(soundFilename.size()); ++i)
+        mSoundFilename.resize(filenameTableSize);
+        for (int i = 0; i < static_cast<int>(mSoundFilename.size()); ++i)
         {
             exe.FAfseek(offset + i * 9 + 1, SEEK_SET);
             auto nameOffset = exe.read32();
-            soundFilename[i] = exe.readCStringFromWin32Binary(nameOffset, codeOffset);
-            soundFilename[i] = Misc::StringUtils::toLower(soundFilename[i]);
-            Misc::StringUtils::replace(soundFilename[i], "\\", "/");
+            mSoundFilename[i] = exe.readCStringFromWin32Binary(nameOffset, codeOffset);
+            mSoundFilename[i] = Misc::StringUtils::toLower(mSoundFilename[i]);
+            Misc::StringUtils::replace(mSoundFilename[i], "\\", "/");
         }
 
         offset = mSettings->get<uint64_t>("Sounds", "itemGraphicsIdToDropSfxId");
-        itemGraphicsIdToDropSfxId.resize(35);
+        mItemGraphicsIdToDropSfxId.resize(35);
         exe.FAfseek(offset, SEEK_SET);
-        for (auto& sfxLookup : itemGraphicsIdToDropSfxId)
+        for (auto& sfxLookup : mItemGraphicsIdToDropSfxId)
             sfxLookup = exe.read32();
 
         offset = mSettings->get<uint64_t>("Sounds", "itemGraphicsIdToInvPlaceSfxId");
-        itemGraphicsIdToInvPlaceSfxId.resize(35);
+        mItemGraphicsIdToInvPlaceSfxId.resize(35);
         exe.FAfseek(offset, SEEK_SET);
-        for (auto& sfxLookup : itemGraphicsIdToInvPlaceSfxId)
+        for (auto& sfxLookup : mItemGraphicsIdToInvPlaceSfxId)
             sfxLookup = exe.read32();
     }
 
@@ -296,9 +296,9 @@ namespace DiabloExe
             BaseItem tmp(exe, codeOffset);
             tmp.id = i;
             auto dropGraphicsId = itemGraphicsIdToDropGraphicsId[tmp.invGraphicsId];
-            tmp.dropItemGraphicsPath = "items/" + itemDropGraphicsFilename[dropGraphicsId] + ".cel";
-            tmp.dropItemSoundPath = soundFilename[itemGraphicsIdToDropSfxId[dropGraphicsId]];
-            tmp.invPlaceItemSoundPath = soundFilename[itemGraphicsIdToInvPlaceSfxId[dropGraphicsId]];
+            tmp.dropItemGraphicsPath = "items/" + mItemDropGraphicsFilename[dropGraphicsId] + ".cel";
+            tmp.dropItemSoundPath = mSoundFilename[mItemGraphicsIdToDropSfxId[dropGraphicsId]];
+            tmp.invPlaceItemSoundPath = mSoundFilename[mItemGraphicsIdToInvPlaceSfxId[dropGraphicsId]];
             auto& s = objCursFrameSizes[tmp.invGraphicsId + 11];
             if (i == 0)
             {

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -161,7 +161,8 @@ namespace DiabloExe
     void DiabloExe::loadSoundFilenames(FAIO::FAFileObject& exe, size_t codeOffset)
     {
         uint64_t offset = mSettings->get<uint64_t>("Sounds", "filenameTable");
-        soundFilename.resize(858);
+        int32_t filenameTableSize = mSettings->get<int32_t>("Sounds", "filenameTableSize");
+        soundFilename.resize(filenameTableSize);
         for (int i = 0; i < static_cast<int>(soundFilename.size()); ++i)
         {
             exe.FAfseek(offset + i * 9 + 1, SEEK_SET);

--- a/components/diabloexe/diabloexe.h
+++ b/components/diabloexe/diabloexe.h
@@ -89,10 +89,10 @@ namespace DiabloExe
         std::vector<UniqueItem> mUniqueItems;
         std::vector<Affix> mAffixes;
         std::vector<std::vector<int32_t>> mTownerAnimation;
-        std::vector<std::string> itemDropGraphicsFilename;
-        std::vector<std::string> soundFilename;
-        std::vector<uint32_t> itemGraphicsIdToDropSfxId;
-        std::vector<uint32_t> itemGraphicsIdToInvPlaceSfxId;
+        std::vector<std::string> mItemDropGraphicsFilename;
+        std::vector<std::string> mSoundFilename;
+        std::vector<uint32_t> mItemGraphicsIdToDropSfxId;
+        std::vector<uint32_t> mItemGraphicsIdToInvPlaceSfxId;
         std::unordered_map<std::string, FontData> mFontData;
     };
 }

--- a/components/diabloexe/diabloexe.h
+++ b/components/diabloexe/diabloexe.h
@@ -70,6 +70,7 @@ namespace DiabloExe
         std::string getVersion(const std::string& pathEXE);
 
         void loadDropGraphicsFilenames(FAIO::FAFileObject& exe, size_t codeOffset);
+        void loadSoundFilenames(FAIO::FAFileObject& exe, size_t codeOffset);
         void loadMonsters(FAIO::FAFileObject& exe, size_t codeOffset);
         void loadNpcs(FAIO::FAFileObject& exe);
         void loadBaseItems(FAIO::FAFileObject& exe, size_t codeOffset);
@@ -89,6 +90,9 @@ namespace DiabloExe
         std::vector<Affix> mAffixes;
         std::vector<std::vector<int32_t>> mTownerAnimation;
         std::vector<std::string> itemDropGraphicsFilename;
+        std::vector<std::string> soundFilename;
+        std::vector<uint32_t> itemGraphicsIdToDropSfxId;
+        std::vector<uint32_t> itemGraphicsIdToInvPlaceSfxId;
         std::unordered_map<std::string, FontData> mFontData;
     };
 }

--- a/resources/exeversions/v109.ini
+++ b/resources/exeversions/v109.ini
@@ -40,7 +40,11 @@ maxLevel=50
 itemGraphicsIdToDropGraphicsId=0x90A38
 filenames=0x90AE4
 frameCounts=0x90B70
-itemGraphicsIdToSfxId=0x90B94
+
+[Sounds]
+filenameTable=0x84170
+itemGraphicsIdToDropSfxId=0x90B94
+itemGraphicsIdToInvPlaceSfxId=0x90C20
 
 [TownerAnimation]
 offset=0xB0524

--- a/resources/exeversions/v109.ini
+++ b/resources/exeversions/v109.ini
@@ -43,6 +43,7 @@ frameCounts=0x90B70
 
 [Sounds]
 filenameTable=0x84170
+filenameTableSize=858
 itemGraphicsIdToDropSfxId=0x90B94
 itemGraphicsIdToInvPlaceSfxId=0x90C20
 


### PR DESCRIPTION
Now plays all the inventory grab/place/flip sounds.
Pulls lookup tables from Diablo.exe.

Also now updates player graphics when equipment changed.
Can be a slight lag since the other graphics files aren't preloaded.
e.g. Mace, armour and shield:
![50888157-e3eb3c00-1459-11e9-8f01-a84f20015448](https://user-images.githubusercontent.com/8636545/50892799-2fa2e300-1464-11e9-9739-951535cecfd2.png)
