### PR TITLE
Fix window scaling issues

### DIFF
--- a/components/render/nuklear_sdl_gl3.cpp
+++ b/components/render/nuklear_sdl_gl3.cpp
@@ -188,7 +188,14 @@ void nk_sdl_render_dump(Render::SpriteCacheBase* cache, NuklearFrameDump& dump, 
         {-1.0f, 1.0f, 0.0f, 1.0f},
     };
     SDL_GetWindowSize(win, &width, &height);
-    SDL_GL_GetDrawableSize(win, &display_width, &display_height);
+
+    // Note: if SDL_GL_GetDrawableSize() is used SDL_WINDOW_ALLOW_HIGHDPI option must
+    // also be enabled. However this seems to cause an issue where black lines appear
+    // between each tile on high-DPI displays so is currently disabled.
+    // SDL_GL_GetDrawableSize(win, &display_width, &display_height);
+    display_width = width;
+    display_height = height;
+
     ortho[0][0] /= (GLfloat)width;
     ortho[1][1] /= (GLfloat)height;
 

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -85,6 +85,10 @@ namespace Render
         if (screen == NULL)
             printf("Could not create window: %s\n", SDL_GetError());
 
+        // Update screen with/height, as starting full screen window in
+        // Windows does not trigger a SDL_WINDOWEVENT_RESIZED event.
+        SDL_GetWindowSize(screen, &WIDTH, &HEIGHT);
+
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -69,7 +69,7 @@ namespace Render
     {
         WIDTH = settings.windowWidth;
         HEIGHT = settings.windowHeight;
-        int flags = SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI;
+        int flags = SDL_WINDOW_OPENGL;
 
         if (settings.fullscreen)
         {

--- a/components/render/sdl2backend.cpp
+++ b/components/render/sdl2backend.cpp
@@ -69,7 +69,7 @@ namespace Render
     {
         WIDTH = settings.windowWidth;
         HEIGHT = settings.windowHeight;
-        int flags = SDL_WINDOW_OPENGL;
+        int flags = SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI;
 
         if (settings.fullscreen)
         {


### PR DESCRIPTION
Fullscreen freeablo worked fine, but launcher and windowed freeablo were way off.
Issue seems to be that [`SDL_GL_GetDrawableSize`](https://wiki.libsdl.org/SDL_GL_GetDrawableSize) always returns the high-DPI count. Either using `SDL_GetWindowSize` instead or enabling high-DPI (`SDL_WINDOW_ALLOW_HIGHDPI`) fixes the issue.
e.g. before:
<img width="300" alt="screen shot 2019-01-27 at 5 09 31 pm" src="https://user-images.githubusercontent.com/8636545/51796407-c3dbbb00-2256-11e9-8125-ab102d899084.png"> <img width="300" alt="screen shot 2019-01-27 at 5 09 40 pm" src="https://user-images.githubusercontent.com/8636545/51796411-c8a06f00-2256-11e9-97af-65eb4dfc98ae.png">
after:
<img width="300" alt="screen shot 2019-01-27 at 5 09 56 pm" src="https://user-images.githubusercontent.com/8636545/51796412-cb9b5f80-2256-11e9-9030-e148cf3f4971.png"> <img width="300" alt="screen shot 2019-01-27 at 5 10 03 pm" src="https://user-images.githubusercontent.com/8636545/51796413-cdfdb980-2256-11e9-8d2e-61d3df9508c2.png">
