### PR TITLE
Fix/select hero menu crash

### DIFF
--- a/apps/freeablo/engine/enginemain.h
+++ b/apps/freeablo/engine/enginemain.h
@@ -33,18 +33,18 @@ namespace Engine
     {
     public:
         EngineMain();
-        ~EngineMain();
+        ~EngineMain() override;
         EngineInputManager& inputManager();
         void run(const cxxopts::ParseResult& variables);
         void stop();
         void togglePause();
         void toggleNoclip();
-        void notify(KeyboardInputAction action);
+        void notify(KeyboardInputAction action) override;
         void setupNewPlayer(FAWorld::Player* player);
         // TODO: replace with enums
         void startGame(const std::string& characterClass);
         void startGameFromSave(const std::string& savePath);
-        void startMultiplayerGame(std::string serverAddress);
+        void startMultiplayerGame(const std::string& serverAddress);
         const DiabloExe::DiabloExe& exe() const;
         bool isPaused() const;
 

--- a/apps/freeablo/fagui/menu/menuscreen.cpp
+++ b/apps/freeablo/fagui/menu/menuscreen.cpp
@@ -28,6 +28,14 @@ namespace FAGui
 
     MenuScreen::ActionResult MenuScreen::drawMenuItems(nk_context* ctx)
     {
+        while (!mInputActions.empty())
+        {
+            auto ret = applyInputAction(mInputActions.front());
+            mInputActions.pop();
+            if (ret == ActionResult::stopDrawing)
+                return ret;
+        }
+
         int index = 0;
         for (auto& item : mMenuItems)
         {
@@ -60,19 +68,21 @@ namespace FAGui
 
     MenuScreen::ActionResult MenuScreen::executeActive() { return mMenuItems[mActiveItemIndex].action(); }
 
-    void MenuScreen::notify(Engine::KeyboardInputAction action)
+    MenuScreen::ActionResult MenuScreen::applyInputAction(Engine::KeyboardInputAction action)
     {
         if (action == Engine::KeyboardInputAction::reject && mRejectAction)
-            mRejectAction();
+            return mRejectAction();
 
         if (mMenuItems.empty())
-            return;
+            return ActionResult::stopDrawing;
+
+        auto ret = ActionResult::continueDrawing;
 
         switch (action)
         {
             case Engine::KeyboardInputAction::accept:
-                mMenuItems[mActiveItemIndex].action();
-                return;
+                ret = executeActive();
+                break;
             case Engine::KeyboardInputAction::nextOption:
                 mActiveItemIndex = (mActiveItemIndex + 1) % mMenuItems.size();
                 break;
@@ -82,5 +92,9 @@ namespace FAGui
             default:
                 break;
         }
+
+        return ret;
     }
+
+    void MenuScreen::notify(Engine::KeyboardInputAction action) { mInputActions.push(action); }
 }

--- a/apps/freeablo/fagui/menu/menuscreen.h
+++ b/apps/freeablo/fagui/menu/menuscreen.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <functional>
+#include <queue>
 #include <vector>
 
 struct nk_context;
@@ -19,14 +20,12 @@ namespace FAGui
     class MenuScreen
     {
     protected:
-        enum class DrawFunctionResult
-        {
+        enum class [[nodiscard]] DrawFunctionResult{
             executeAction,
             setActive,
             noAction,
         };
-        enum class ActionResult
-        {
+        enum class [[nodiscard]] ActionResult{
             stopDrawing,
             continueDrawing,
         };
@@ -47,11 +46,13 @@ namespace FAGui
         static void menuText(nk_context* ctx, const char* text, MenuFontColor color, int fontSize, uint32_t textAlignment);
         ActionResult drawMenuItems(nk_context* ctx);
         ActionResult executeActive();
+        ActionResult applyInputAction(Engine::KeyboardInputAction action);
 
     protected:
         MenuHandler& mMenuHandler;
         std::function<ActionResult()> mRejectAction;
         std::vector<MenuItem> mMenuItems;
+        std::queue<Engine::KeyboardInputAction> mInputActions;
         int mActiveItemIndex = 0;
     };
 }

--- a/apps/freeablo/fagui/menu/multiplayerconnecting.cpp
+++ b/apps/freeablo/fagui/menu/multiplayerconnecting.cpp
@@ -49,7 +49,7 @@ namespace FAGui
         nk_end(ctx);
 
         if (exit)
-            mRejectAction();
+            (void)mRejectAction();
 
         auto multiplayer = static_cast<Engine::Client*>(mMenuHandler.engine().mMultiplayer.get());
 

--- a/apps/freeablo/faworld/actorstats.cpp
+++ b/apps/freeablo/faworld/actorstats.cpp
@@ -15,7 +15,7 @@ namespace FAWorld
         size_t size = size_t(loader.load<int32_t>());
         mLevelXpCounts.reserve(size);
         for (size_t i = 0; i < size; i++)
-            mLevelXpCounts.push_back(loader.load<int32_t>());
+            mLevelXpCounts.push_back(loader.load<uint32_t>());
     }
 
     void ActorStats::save(FASaveGame::GameSaver& saver)


### PR DESCRIPTION
Fix crash when enter hit twice on SelectHeroMenuScreen.
Also fix some Clang-Tidy (static analysis) warnings in EngineMain