### PR TITLE
Add animations for casting spells and fire arrows for ranged weapons

### DIFF
--- a/apps/freeablo/engine/localinputhandler.cpp
+++ b/apps/freeablo/engine/localinputhandler.cpp
@@ -74,7 +74,11 @@ namespace Engine
 
                 auto cursorItem = player->mInventory.getCursorHeld();
                 auto clickedActor = mWorld.targetedActor(mousePosition);
-                if (cursorItem.isEmpty() && clickedActor)
+                if (modifiers.shift && cursorItem.isEmpty())
+                {
+                    mInputs.emplace_back(FAWorld::PlayerInput::ForceAttackData{clickedTile.pos}, player->getId());
+                }
+                else if (clickedActor && cursorItem.isEmpty())
                 {
                     mInputs.emplace_back(FAWorld::PlayerInput::TargetActorData{clickedActor->getId()}, player->getId());
                 }
@@ -83,10 +87,6 @@ namespace Engine
                     auto type = EngineMain::get()->mGuiManager->isInventoryShown() ? FAWorld::Target::ItemTarget::ActionType::toCursor
                                                                                    : FAWorld::Target::ItemTarget::ActionType::autoEquip;
                     mInputs.emplace_back(FAWorld::PlayerInput::TargetItemOnFloorData{item->getTile().position, type}, player->getId());
-                }
-                else if (modifiers.shift)
-                {
-                    mInputs.emplace_back(FAWorld::PlayerInput::ForceAttackData{clickedTile.pos}, player->getId());
                 }
                 else if (player->getLevel()->isDoor(clickedTile.pos) || !cursorItem.isEmpty())
                 {
@@ -109,7 +109,7 @@ namespace Engine
             }
             case Engine::MouseInputAction::MOUSE_MOVE:
             {
-                if (mouseDown && player->mInventory.getCursorHeld().isEmpty())
+                if (mouseDown && !modifiers.shift && player->mInventory.getCursorHeld().isEmpty())
                 {
                     auto clickedTile = FARender::Renderer::get()->getTileByScreenPos(mousePosition.x, mousePosition.y, player->getPos());
                     mInputs.emplace_back(FAWorld::PlayerInput::DragOverTileData{clickedTile.pos.x, clickedTile.pos.y}, player->getId());

--- a/apps/freeablo/engine/localinputhandler.cpp
+++ b/apps/freeablo/engine/localinputhandler.cpp
@@ -86,9 +86,7 @@ namespace Engine
                 }
                 else if (modifiers.shift)
                 {
-                    Misc::Direction direction =
-                        Vec2Fix(clickedTile.pos.x - player->getPos().current().x, clickedTile.pos.y - player->getPos().current().y).getDirection();
-                    mInputs.emplace_back(FAWorld::PlayerInput::AttackDirectionData{direction}, player->getId());
+                    mInputs.emplace_back(FAWorld::PlayerInput::ForceAttackData{clickedTile.pos}, player->getId());
                 }
                 else if (player->getLevel()->isDoor(clickedTile.pos) || !cursorItem.isEmpty())
                 {

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -347,7 +347,7 @@ namespace FAWorld
         doMeleeHit(actor);
     }
 
-    void Actor::startMeleeAttack(Misc::Direction direction) { mMeleeAttackRequestedDirection = direction; }
+    void Actor::forceAttack(Misc::Point pos) { mForceAttackRequestedPoint = pos; }
 
     void Actor::doMeleeHit(Actor* enemy)
     {
@@ -391,13 +391,27 @@ namespace FAWorld
         }
     }
 
+    bool Actor::hasRangedWeaponEquipped() const { return mInventory.isRangedWeaponEquipped(); }
+
+    void Actor::doRangedAttack(Misc::Point targetPoint)
+    {
+        Engine::ThreadManager::get()->playSound("sfx/misc/bfire.wav");
+        // Note: Fire and lightning arrows are also possible.
+        activateMissile(MissileId::arrow, targetPoint);
+    }
+
     bool Actor::castSpell(SpellId spell, Misc::Point targetPoint)
+    {
+        mCastSpellRequest = std::pair(spell, targetPoint);
+        return true;
+    }
+
+    void Actor::doSpellEffect(SpellId spell, Misc::Point targetPoint)
     {
         auto spellData = SpellData(spell);
         Engine::ThreadManager::get()->playSound(spellData.soundEffect());
         for (auto missileId : spellData.missiles())
             activateMissile(missileId, targetPoint);
-        return true;
     }
 
     void Actor::activateMissile(MissileId id, Misc::Point targetPoint)

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -58,7 +58,7 @@ namespace FAWorld
         virtual bool canCriticalHit() const { return false; }
         void doMeleeHit(Actor* enemy);
         void doMeleeHit(const Misc::Point& point);
-        void startMeleeAttack(Misc::Direction direction);
+        void forceAttack(Misc::Point pos);
         std::string getDieWav() const;
         std::string getHitWav() const;
         bool canIAttack(Actor* actor);
@@ -87,7 +87,10 @@ namespace FAWorld
         void dealDamageToEnemy(Actor* enemy, uint32_t damage, DamageType type);
         virtual void calculateStats(LiveActorStats& stats, const ActorStats& actorStats) const;
         const std::vector<std::unique_ptr<Missile::Missile>>& getMissiles() const { return mMissiles; }
+        bool hasRangedWeaponEquipped() const;
+        void doRangedAttack(Misc::Point targetPoint);
         virtual bool castSpell(SpellId spell, Misc::Point targetPoint);
+        virtual void doSpellEffect(SpellId spell, Misc::Point targetPoint);
         ActorType getType() const { return mType; }
         bool isRecoveringFromHit() const;
         int32_t getMeleeHitFrame() const { return mMeleeHitFrame; }
@@ -104,7 +107,8 @@ namespace FAWorld
         bool isAttacking = false;
         bool mInvuln = false;
         CharacterInventory mInventory;
-        std::optional<Misc::Direction> mMeleeAttackRequestedDirection; // this is really stupid but I don't know how else to do it
+        std::optional<Misc::Point> mForceAttackRequestedPoint; // this is really stupid but I don't know how else to do it
+        std::optional<std::pair<SpellId, Misc::Point>> mCastSpellRequest;
 
         // TODO: hack, this should eventually be removed.
         // Try not to use it unless you have no other choice with the current structure.

--- a/apps/freeablo/faworld/actor/attackstate.cpp
+++ b/apps/freeablo/faworld/actor/attackstate.cpp
@@ -1,47 +1,107 @@
 #include "attackstate.h"
 #include "../../fasavegame/gameloader.h"
 #include "../actor.h"
+#include "../spells.h"
 
 namespace FAWorld
 {
-
     namespace ActorState
     {
-        const std::string MeleeAttackState::typeId = "actorstate-attack-state";
+        const std::string BaseAttackState::typeId = "actorstate-base-attack-state";
 
-        void MeleeAttackState::save(FASaveGame::GameSaver& saver) const { mDirection.save(saver); }
+        void BaseAttackState::save(FASaveGame::GameSaver& saver) const
+        {
+            mTargetPoint.save(saver);
+            saver.save(mAttackDone);
+        }
 
-        MeleeAttackState::MeleeAttackState(FASaveGame::GameLoader& loader) { mDirection = Misc::Direction(loader); }
+        BaseAttackState::BaseAttackState(FASaveGame::GameLoader& loader)
+        {
+            mTargetPoint = Misc::Point(loader);
+            mAttackDone = loader.load<bool>();
+        }
 
-        MeleeAttackState::MeleeAttackState(Misc::Direction direction) : mDirection(direction) {}
+        BaseAttackState::BaseAttackState(Misc::Point targetPoint) : mTargetPoint(targetPoint) {}
 
-        std::optional<StateChange> MeleeAttackState::update(Actor& actor, bool noclip)
+        std::optional<StateChange> BaseAttackState::update(Actor& actor, bool noclip)
         {
             UNUSED_PARAM(noclip);
 
             auto& animManager = actor.mAnimation;
-            if (animManager.getCurrentAnimation() != AnimState::attack)
+            if (animManager.getCurrentAnimation() != getAnimation())
             {
                 actor.isAttacking = false;
                 return StateChange{StateOperation::pop};
             }
 
-            int32_t attackFrame = actor.getMeleeHitFrame();
-            if (!mHitDone && // to fix the problem with several updates during a single frame
+            int32_t attackFrame = getAttackFrame(actor);
+            if (!mAttackDone && // to fix the problem with several updates during a single frame
                 actor.mAnimation.getCurrentRealFrame().second == attackFrame)
             {
-                actor.doMeleeHit(Misc::getNextPosByDir(actor.getPos().current(), mDirection));
-                mHitDone = true;
+                doAttack(actor);
+                mAttackDone = true;
             }
 
             return std::nullopt;
         }
 
-        void MeleeAttackState::onEnter(Actor& actor)
+        void BaseAttackState::onEnter(Actor& actor)
         {
             actor.isAttacking = true;
-            actor.stopMoving(mDirection);
-            actor.mAnimation.playAnimation(AnimState::attack, FARender::AnimationPlayer::AnimationType::Once);
+            auto actorPos = actor.getPos().current();
+            auto direction = Vec2Fix(mTargetPoint.x - actorPos.x, mTargetPoint.y - actorPos.y).getDirection();
+            actor.stopMoving(direction);
+            actor.mAnimation.playAnimation(getAnimation(), FARender::AnimationPlayer::AnimationType::Once);
+        }
+
+        const std::string MeleeAttackState::typeId = "actorstate-melee-attack-state";
+
+        void MeleeAttackState::doAttack(Actor& actor)
+        {
+            // Melee can only attack the nearest position/tile in a direction.
+            auto actorPos = actor.getPos().current();
+            auto direction = Vec2Fix(mTargetPoint.x - actorPos.x, mTargetPoint.y - actorPos.y).getDirection();
+            auto pos = getNextPosByDir(actorPos, direction);
+            actor.doMeleeHit(pos);
+        }
+
+        int32_t MeleeAttackState::getAttackFrame(Actor& actor) const { return actor.getMeleeHitFrame(); }
+
+        const std::string RangedAttackState::typeId = "actorstate-ranged-attack-state";
+
+        void RangedAttackState::doAttack(Actor& actor) { actor.doRangedAttack(mTargetPoint); }
+
+        const std::string SpellAttackState::typeId = "actorstate-spell-attack-state";
+
+        void SpellAttackState::save(FASaveGame::GameSaver& saver) const
+        {
+            BaseAttackState::save(saver);
+            saver.save((int32_t)mSpell);
+        }
+
+        SpellAttackState::SpellAttackState(FASaveGame::GameLoader& loader) : BaseAttackState(loader) { mSpell = (SpellId)loader.load<int32_t>(); }
+
+        void SpellAttackState::doAttack(Actor& actor) { actor.doSpellEffect(mSpell, mTargetPoint); }
+
+        AnimState SpellAttackState::getAnimation() const
+        {
+            auto spellData = SpellData(mSpell);
+            switch (spellData.getType())
+            {
+                case SpellType::fire:
+                    return AnimState::spellFire;
+                case SpellType::lightning:
+                    return AnimState::spellLightning;
+                case SpellType::magic:
+                default:
+                    return AnimState::spellOther;
+            }
+        }
+
+        int32_t SpellAttackState::getAttackFrame(Actor& actor) const
+        {
+            // Initiate spell on the last frame.
+            return actor.mAnimation.getAnimationSprites(getAnimation())->getAnimLength() - 1;
         }
     }
 }

--- a/apps/freeablo/faworld/actor/attackstate.cpp
+++ b/apps/freeablo/faworld/actor/attackstate.cpp
@@ -7,8 +7,6 @@ namespace FAWorld
 {
     namespace ActorState
     {
-        const std::string BaseAttackState::typeId = "actorstate-base-attack-state";
-
         void BaseAttackState::save(FASaveGame::GameSaver& saver) const
         {
             mTargetPoint.save(saver);
@@ -88,11 +86,11 @@ namespace FAWorld
             auto spellData = SpellData(mSpell);
             switch (spellData.getType())
             {
-                case SpellType::fire:
+                case DiabloExe::SpellData::SpellType::fire:
                     return AnimState::spellFire;
-                case SpellType::lightning:
+                case DiabloExe::SpellData::SpellType::lightning:
                     return AnimState::spellLightning;
-                case SpellType::magic:
+                case DiabloExe::SpellData::SpellType::magic:
                 default:
                     return AnimState::spellOther;
             }

--- a/apps/freeablo/faworld/actor/attackstate.h
+++ b/apps/freeablo/faworld/actor/attackstate.h
@@ -14,9 +14,6 @@ namespace FAWorld
         class BaseAttackState : public AbstractState
         {
         public:
-            static const std::string typeId;
-            const std::string& getTypeId() const override { return typeId; }
-
             virtual void save(FASaveGame::GameSaver& saver) const override;
 
             explicit BaseAttackState(FASaveGame::GameLoader& loader);
@@ -39,6 +36,7 @@ namespace FAWorld
         {
         public:
             static const std::string typeId;
+            const std::string& getTypeId() const override { return typeId; }
 
             explicit MeleeAttackState(FASaveGame::GameLoader& loader) : BaseAttackState(loader) {}
             explicit MeleeAttackState(Misc::Point targetPoint) : BaseAttackState(targetPoint) {}
@@ -53,6 +51,7 @@ namespace FAWorld
         {
         public:
             static const std::string typeId;
+            const std::string& getTypeId() const override { return typeId; }
 
             explicit RangedAttackState(FASaveGame::GameLoader& loader) : MeleeAttackState(loader) {}
             explicit RangedAttackState(Misc::Point targetPoint) : MeleeAttackState(targetPoint) {}
@@ -65,6 +64,7 @@ namespace FAWorld
         {
         public:
             static const std::string typeId;
+            const std::string& getTypeId() const override { return typeId; }
 
             void save(FASaveGame::GameSaver& saver) const override;
 

--- a/apps/freeablo/faworld/actoranimationmanager.h
+++ b/apps/freeablo/faworld/actoranimationmanager.h
@@ -21,6 +21,9 @@ namespace FAWorld
         hit,
         block,
         none,
+        spellLightning,
+        spellFire,
+        spellOther,
         ENUM_END // always leave this as the last entry, and don't set explicit values for any of the entries
     };
 

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -492,10 +492,12 @@ namespace FAWorld
         if (!renderer) // TODO: some sort of headless mode for tests
             return;
 
-        // TODO: Spell animations: lightning "lm", fire "fm", other "qm"
         mAnimation.setAnimationSprites(AnimState::dead, renderer->loadImage(helper(true, "dt")));
         mAnimation.setAnimationSprites(AnimState::attack, renderer->loadImage(helper(false, "at")));
         mAnimation.setAnimationSprites(AnimState::hit, renderer->loadImage(helper(false, "ht")));
+        mAnimation.setAnimationSprites(AnimState::spellLightning, renderer->loadImage(helper(false, "lm")));
+        mAnimation.setAnimationSprites(AnimState::spellFire, renderer->loadImage(helper(false, "fm")));
+        mAnimation.setAnimationSprites(AnimState::spellOther, renderer->loadImage(helper(false, "qm")));
 
         if (mInventory.isShieldEquipped())
             mAnimation.setAnimationSprites(AnimState::block, renderer->loadImage(helper(false, "bl")));
@@ -619,22 +621,37 @@ namespace FAWorld
     bool Player::castSpell(SpellId spell, Misc::Point targetPoint)
     {
         if (spell == SpellId::null)
+        {
+            // TODO: Play player sound #34: "I don't have a spell ready"
             return false;
+        }
 
         auto spellData = SpellData(spell);
         auto& mana = mStats.getMana();
         auto manaCost = spellData.manaCost();
 
         // Note: These checks have temporarily been removed for easier testing/development
-        // if (!getLevel() || (getLevel()->isTown() && !spellData.canCastInTown()) || mana.current < manaCost)
-        //    return false;
-
-        if (Actor::castSpell(spell, targetPoint))
+        if (!getLevel() || (getLevel()->isTown() && !spellData.canCastInTown()))
         {
-            mana.add(-manaCost);
-            return true;
+            // TODO: Play player sound #27: "I can't cast that here"
+            // return false;
         }
-        return false;
+        if (mana.current < manaCost)
+        {
+            // TODO: Play player sound #35: "Not enough mana"
+            // return false;
+        }
+
+        return Actor::castSpell(spell, targetPoint);
+    }
+
+    void Player::doSpellEffect(SpellId spell, Misc::Point targetPoint)
+    {
+        auto spellData = SpellData(spell);
+        auto& mana = mStats.getMana();
+        auto manaCost = spellData.manaCost();
+        mana.add(-manaCost);
+        Actor::doSpellEffect(spell, targetPoint);
     }
 
     SpellId Player::defaultSkill() const

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -42,6 +42,7 @@ namespace FAWorld
         virtual bool canCriticalHit() const override { return mPlayerClass == PlayerClass::warrior; }
 
         bool castSpell(SpellId spell, Misc::Point targetPoint) override;
+        void doSpellEffect(SpellId spell, Misc::Point targetPoint) override;
         SpellId defaultSkill() const;
 
         virtual void calculateStats(LiveActorStats& stats, const ActorStats& actorStats) const override;

--- a/apps/freeablo/faworld/playerbehaviour.cpp
+++ b/apps/freeablo/faworld/playerbehaviour.cpp
@@ -105,10 +105,10 @@ namespace FAWorld
                 mPlayer->mTarget = Target::ItemTarget{input.mData.dataTargetItemOnFloor.type, item};
                 return;
             }
-            case PlayerInput::Type::AttackDirection:
+            case PlayerInput::Type::ForceAttack:
             {
                 if (!mPlayer->getLevel()->isTown())
-                    mPlayer->startMeleeAttack(input.mData.dataAttackDirection.direction);
+                    mPlayer->forceAttack(input.mData.dataForceAttack.pos);
                 return;
             }
             case PlayerInput::Type::CastSpell:

--- a/apps/freeablo/faworld/playerinput.cpp
+++ b/apps/freeablo/faworld/playerinput.cpp
@@ -98,9 +98,9 @@ namespace FAWorld
         type = Target::ItemTarget::ActionType(loader.load<uint8_t>());
     }
 
-    void PlayerInput::AttackDirectionData::save(Serial::Saver& saver) const { direction.save(saver); }
+    void PlayerInput::ForceAttackData::save(Serial::Saver& saver) const { pos.save(saver); }
 
-    void PlayerInput::AttackDirectionData::load(Serial::Loader& loader) { direction = Misc::Direction(loader); }
+    void PlayerInput::ForceAttackData::load(Serial::Loader& loader) { pos = Misc::Point(loader); }
 
     void PlayerInput::CastSpellData::save(Serial::Saver& saver) const
     {

--- a/apps/freeablo/faworld/playerinput.h
+++ b/apps/freeablo/faworld/playerinput.h
@@ -10,7 +10,7 @@
     MACRO(DragOverTile)                                                                                                                                        \
     MACRO(TargetActor)                                                                                                                                         \
     MACRO(TargetItemOnFloor)                                                                                                                                   \
-    MACRO(AttackDirection)                                                                                                                                     \
+    MACRO(ForceAttack)                                                                                                                                         \
     MACRO(CastSpell)                                                                                                                                           \
     MACRO(ChangeLevel)                                                                                                                                         \
     MACRO(InventorySlotClicked)                                                                                                                                \
@@ -63,9 +63,9 @@ namespace FAWorld
             void save(Serial::Saver& saver) const;
             void load(Serial::Loader& loader);
         };
-        struct AttackDirectionData
+        struct ForceAttackData
         {
-            Misc::Direction direction;
+            Misc::Point pos;
 
             void save(Serial::Saver& saver) const;
             void load(Serial::Loader& loader);

--- a/apps/freeablo/faworld/spells.h
+++ b/apps/freeablo/faworld/spells.h
@@ -6,13 +6,6 @@
 
 namespace FAWorld
 {
-    enum class SpellType
-    {
-        fire,
-        lightning,
-        magic
-    };
-
     class SpellData
     {
     public:
@@ -26,19 +19,7 @@ namespace FAWorld
 
         const std::string& soundEffect() const { return mSpellData.mSoundEffect; }
 
-        SpellType getType() const
-        {
-            switch (mSpellData.mType)
-            {
-                case 0:
-                    return SpellType::fire;
-                case 1:
-                    return SpellType::lightning;
-                case 2:
-                default:
-                    return SpellType::magic;
-            }
-        }
+        DiabloExe::SpellData::SpellType getType() const { return mSpellData.mType; }
 
         std::vector<MissileId> missiles() const
         {

--- a/apps/freeablo/faworld/spells.h
+++ b/apps/freeablo/faworld/spells.h
@@ -1,10 +1,18 @@
 #pragma once
 #include "diabloexe/diabloexe.h"
+#include "engine/enginemain.h"
 #include "missile/missileenums.h"
 #include "spellenums.h"
 
 namespace FAWorld
 {
+    enum class SpellType
+    {
+        fire,
+        lightning,
+        magic
+    };
+
     class SpellData
     {
     public:
@@ -17,6 +25,20 @@ namespace FAWorld
         int32_t manaCost() const { return mSpellData.mManaCost; }
 
         const std::string& soundEffect() const { return mSpellData.mSoundEffect; }
+
+        SpellType getType() const
+        {
+            switch (mSpellData.mType)
+            {
+                case 0:
+                    return SpellType::fire;
+                case 1:
+                    return SpellType::lightning;
+                case 2:
+                default:
+                    return SpellType::magic;
+            }
+        }
 
         std::vector<MissileId> missiles() const
         {

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -115,6 +115,9 @@ namespace FAWorld
         mObjectIdMapper.addClass(PlayerBehaviour::typeId, [](FASaveGame::GameLoader& loader) { return new PlayerBehaviour(loader); });
 
         mObjectIdMapper.addClass(ActorState::MeleeAttackState::typeId, [](FASaveGame::GameLoader& loader) { return new ActorState::MeleeAttackState(loader); });
+        mObjectIdMapper.addClass(ActorState::RangedAttackState::typeId,
+                                 [](FASaveGame::GameLoader& loader) { return new ActorState::RangedAttackState(loader); });
+        mObjectIdMapper.addClass(ActorState::SpellAttackState::typeId, [](FASaveGame::GameLoader& loader) { return new ActorState::SpellAttackState(loader); });
         mObjectIdMapper.addClass(ActorState::BaseState::typeId, [](FASaveGame::GameLoader&) { return new ActorState::BaseState(); });
     }
 

--- a/components/diabloexe/diabloexe.cpp
+++ b/components/diabloexe/diabloexe.cpp
@@ -564,7 +564,20 @@ namespace DiabloExe
             auto spellId = exe.read8();
             auto& spellData = mSpellsDataTable[spellId];
             spellData.mManaCost = exe.read8();
-            spellData.mType = exe.read8();
+            int8_t type = exe.read8();
+            switch (type)
+            {
+                case 0:
+                    spellData.mType = SpellData::SpellType::fire;
+                    break;
+                case 1:
+                    spellData.mType = SpellData::SpellType::lightning;
+                    break;
+                case 2:
+                default:
+                    spellData.mType = SpellData::SpellType::magic;
+                    break;
+            }
             exe.read8(); // Padding
             auto nameOffset = exe.read32();
             auto skillTextOffset = exe.read32();
@@ -573,8 +586,8 @@ namespace DiabloExe
             spellData.mTargeted = (bool)exe.read32();
             spellData.mTownSpell = (bool)exe.read32();
             spellData.mMinMagic = exe.read32();
-            int32_t soundEffectId = exe.read8();
-            spellData.mSoundEffect = soundEffectId == -1 ? "" : mSoundFilename[soundEffectId];
+            int8_t soundEffectId = exe.read8();
+            spellData.mSoundEffect = mSoundFilename[soundEffectId];
             for (auto& missile : spellData.mMissiles)
                 missile = exe.read8();
             spellData.mManaAdj = exe.read8();

--- a/components/diabloexe/diabloexe.h
+++ b/components/diabloexe/diabloexe.h
@@ -59,8 +59,15 @@ namespace DiabloExe
     class SpellData
     {
     public:
+        enum class SpellType
+        {
+            fire,
+            lightning,
+            magic
+        };
+
         int32_t mManaCost;
-        int32_t mType; // Fire=0, lightning=1, magic=2
+        SpellType mType;
         std::string mNameText;
         std::string mSkillText;
         int32_t mBookLvl;


### PR DESCRIPTION
Added `RangedAttackState` and `SpellAttackState` classes (similar to MeleeAttackState) and a common ABC. Added other minor bits to enable spell casting animations and firing arrows.
Renamed "AttackDirection" input to "ForceAttack" and changed its data to a target point instead of a direction (as ranged/bow attacks require this information).
This probably almost closes #46 (Bows) too