### PR TITLE
Fix/save const correctness

### DIFF
--- a/apps/freeablo/farender/animationplayer.cpp
+++ b/apps/freeablo/farender/animationplayer.cpp
@@ -23,7 +23,7 @@ namespace FARender
             mFrameSequence.push_back(loader.load<int32_t>());
     }
 
-    void AnimationPlayer::save(FASaveGame::GameSaver& saver)
+    void AnimationPlayer::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("AnimationPlayer", saver);
 

--- a/apps/freeablo/farender/animationplayer.h
+++ b/apps/freeablo/farender/animationplayer.h
@@ -25,7 +25,7 @@ namespace FARender
 
         AnimationPlayer() {}
         AnimationPlayer(FASaveGame::GameLoader& loader);
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
 
         std::pair<FARender::FASpriteGroup*, int32_t> getCurrentFrame();
         AnimationType getCurrentAnimationType() { return mPlayingAnimType; }

--- a/apps/freeablo/faworld/actor.cpp
+++ b/apps/freeablo/faworld/actor.cpp
@@ -126,7 +126,7 @@ namespace FAWorld
         mType = ActorType(loader.load<uint8_t>());
     }
 
-    void Actor::save(FASaveGame::GameSaver& saver)
+    void Actor::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("Actor", saver);
 

--- a/apps/freeablo/faworld/actor.h
+++ b/apps/freeablo/faworld/actor.h
@@ -46,7 +46,7 @@ namespace FAWorld
         Actor(World& world, const DiabloExe::Npc& npc, const DiabloExe::DiabloExe& exe);
         Actor(World& world, FASaveGame::GameLoader& loader);
         virtual ~Actor();
-        virtual void save(FASaveGame::GameSaver& saver);
+        virtual void save(FASaveGame::GameSaver& saver) const;
 
         virtual int32_t getOnKilledExperience() const { return 0; }
         void pickupItem(Target::ItemTarget target);

--- a/apps/freeablo/faworld/actoranimationmanager.cpp
+++ b/apps/freeablo/faworld/actoranimationmanager.cpp
@@ -46,7 +46,7 @@ namespace FAWorld
         mInterruptedAnimationFrame = loader.load<int32_t>();
     }
 
-    void ActorAnimationManager::save(FASaveGame::GameSaver& saver)
+    void ActorAnimationManager::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("ActorAnimationManager", saver);
 

--- a/apps/freeablo/faworld/actoranimationmanager.h
+++ b/apps/freeablo/faworld/actoranimationmanager.h
@@ -32,7 +32,7 @@ namespace FAWorld
     public:
         ActorAnimationManager();
         ActorAnimationManager(FASaveGame::GameLoader& loader);
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
 
         void initAnimMaps();
 

--- a/apps/freeablo/faworld/actorstats.cpp
+++ b/apps/freeablo/faworld/actorstats.cpp
@@ -26,7 +26,7 @@ namespace FAWorld
             mLevelXpCounts.push_back(loader.load<uint32_t>());
     }
 
-    void ActorStats::save(FASaveGame::GameSaver& saver)
+    void ActorStats::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("ActorStats", saver);
 
@@ -69,7 +69,7 @@ namespace FAWorld
             mMana.setMax(mCalculatedStats.maxMana);
     }
 
-    void BaseStats::save(FASaveGame::GameSaver& saver)
+    void BaseStats::save(FASaveGame::GameSaver& saver) const
     {
         saver.save(strength);
         saver.save(magic);

--- a/apps/freeablo/faworld/actorstats.h
+++ b/apps/freeablo/faworld/actorstats.h
@@ -21,7 +21,7 @@ namespace FAWorld
 {
     struct BaseStats
     {
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
         void load(FASaveGame::GameLoader& loader);
 
         int32_t strength = 0;
@@ -84,7 +84,7 @@ namespace FAWorld
         void initialise(const BaseStats& baseStats);
 
         ActorStats(const Actor& actor, FASaveGame::GameLoader& loader);
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
 
         ActorStats& operator=(const ActorStats& other) = default;
 

--- a/apps/freeablo/faworld/behaviour.cpp
+++ b/apps/freeablo/faworld/behaviour.cpp
@@ -42,7 +42,7 @@ namespace FAWorld
 
     BasicMonsterBehaviour::BasicMonsterBehaviour(FASaveGame::GameLoader& loader) { mTicksSinceLastAction = loader.load<Tick>(); }
 
-    void BasicMonsterBehaviour::save(FASaveGame::GameSaver& saver)
+    void BasicMonsterBehaviour::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("BasicMonsterBehaviour", saver);
 

--- a/apps/freeablo/faworld/behaviour.h
+++ b/apps/freeablo/faworld/behaviour.h
@@ -21,7 +21,7 @@ namespace FAWorld
         Behaviour() = default;
 
         virtual const std::string& getTypeId() = 0;
-        virtual void save(FASaveGame::GameSaver& saver) = 0;
+        virtual void save(FASaveGame::GameSaver& saver) const = 0;
         virtual void update() = 0;
 
         virtual ~Behaviour() {}
@@ -41,7 +41,7 @@ namespace FAWorld
         NullBehaviour(FAWorld::Actor* actor) : Behaviour(actor) {}
         NullBehaviour() = default;
 
-        virtual void save(FASaveGame::GameSaver&) override {}
+        virtual void save(FASaveGame::GameSaver&) const override {}
         virtual void update() override {}
 
         virtual ~NullBehaviour() {}
@@ -56,7 +56,7 @@ namespace FAWorld
         BasicMonsterBehaviour(FAWorld::Actor* monster) : Behaviour(monster) {}
         BasicMonsterBehaviour(FASaveGame::GameLoader& loader);
 
-        virtual void save(FASaveGame::GameSaver& saver) override;
+        virtual void save(FASaveGame::GameSaver& saver) const override;
         virtual void update() override;
 
         virtual ~BasicMonsterBehaviour() {}

--- a/apps/freeablo/faworld/faction.h
+++ b/apps/freeablo/faworld/faction.h
@@ -27,7 +27,7 @@ namespace FAWorld
 
         static Faction heaven() { return Faction(FactionType::heaven); }
 
-        FactionType getType() { return mFaction; }
+        FactionType getType() const { return mFaction; }
 
     private:
         FactionType mFaction;

--- a/apps/freeablo/faworld/gamelevel.cpp
+++ b/apps/freeablo/faworld/gamelevel.cpp
@@ -37,7 +37,7 @@ namespace FAWorld
         actorMapRefresh();
     }
 
-    void GameLevel::save(FASaveGame::GameSaver& saver)
+    void GameLevel::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("GameLevel", saver);
 

--- a/apps/freeablo/faworld/gamelevel.h
+++ b/apps/freeablo/faworld/gamelevel.h
@@ -54,7 +54,7 @@ namespace FAWorld
 
         GameLevel(World& world, FASaveGame::GameLoader& gameLoader);
 
-        void save(FASaveGame::GameSaver& gameSaver);
+        void save(FASaveGame::GameSaver& gameSaver) const;
 
         ~GameLevel();
 

--- a/apps/freeablo/faworld/inventory.cpp
+++ b/apps/freeablo/faworld/inventory.cpp
@@ -28,7 +28,7 @@ namespace FAWorld
         }
     }
 
-    void BasicInventory::save(FASaveGame::GameSaver& saver)
+    void BasicInventory::save(FASaveGame::GameSaver& saver) const
     {
         saver.save(mInventoryBox.width());
         saver.save(mInventoryBox.height());
@@ -317,7 +317,7 @@ namespace FAWorld
         }
     }
 
-    void CharacterInventory::save(FASaveGame::GameSaver& saver)
+    void CharacterInventory::save(FASaveGame::GameSaver& saver) const
     {
         mMainInventory.save(saver);
         mBelt.save(saver);

--- a/apps/freeablo/faworld/inventory.h
+++ b/apps/freeablo/faworld/inventory.h
@@ -61,7 +61,7 @@ namespace FAWorld
     public:
         BasicInventory(int32_t width, int32_t height, bool treatAllItemsAs1By1 = false);
 
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
         void load(FASaveGame::GameLoader& loader);
 
         bool canFitItem(const Item& item) const;
@@ -97,7 +97,7 @@ namespace FAWorld
     {
     public:
         CharacterInventory();
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
         void load(FASaveGame::GameLoader& loader);
 
         bool autoPlaceItem(const Item& item);

--- a/apps/freeablo/faworld/itemmap.cpp
+++ b/apps/freeablo/faworld/itemmap.cpp
@@ -52,7 +52,7 @@ namespace FAWorld
         }
     }
 
-    void ItemMap::save(FASaveGame::GameSaver& saver)
+    void ItemMap::save(FASaveGame::GameSaver& saver) const
     {
         uint32_t itemsSize = uint32_t(mItems.size());
         saver.save(itemsSize);

--- a/apps/freeablo/faworld/itemmap.h
+++ b/apps/freeablo/faworld/itemmap.h
@@ -72,7 +72,7 @@ namespace FAWorld
         ItemMap(const GameLevel* level);
         ItemMap(FASaveGame::GameLoader& loader, const GameLevel* level);
 
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
 
         ~ItemMap();
         bool dropItem(std::unique_ptr<FAWorld::Item>&& item, const Actor& actor, const Tile& tile);

--- a/apps/freeablo/faworld/missile/missile.cpp
+++ b/apps/freeablo/faworld/missile/missile.cpp
@@ -31,7 +31,7 @@ namespace FAWorld::Missile
             mGraphics.push_back(std::make_unique<MissileGraphic>(loader));
     }
 
-    void Missile::save(FASaveGame::GameSaver& saver)
+    void Missile::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("Missile", saver);
 

--- a/apps/freeablo/faworld/missile/missile.h
+++ b/apps/freeablo/faworld/missile/missile.h
@@ -26,7 +26,7 @@ namespace FAWorld::Missile
         Missile(MissileId missileId, Actor& creator, Misc::Point dest);
         Missile(FASaveGame::GameLoader& loader);
 
-        virtual void save(FASaveGame::GameSaver& saver);
+        virtual void save(FASaveGame::GameSaver& saver) const;
         virtual void update();
         virtual bool isComplete() const { return mComplete; }
         MissileId getMissileId() const { return mMissileId; }

--- a/apps/freeablo/faworld/missile/missilegraphic.cpp
+++ b/apps/freeablo/faworld/missile/missilegraphic.cpp
@@ -33,7 +33,7 @@ namespace FAWorld::Missile
 
     MissileGraphic::~MissileGraphic() { mLevel->mMissileGraphics.erase(this); }
 
-    void MissileGraphic::save(FASaveGame::GameSaver& saver)
+    void MissileGraphic::save(FASaveGame::GameSaver& saver) const
     {
         mCurPos.save(saver);
         saver.save(mMainGraphicPath);

--- a/apps/freeablo/faworld/missile/missilegraphic.h
+++ b/apps/freeablo/faworld/missile/missilegraphic.h
@@ -20,7 +20,7 @@ namespace FAWorld::Missile
         MissileGraphic(std::string initialGraphicPath, std::string mainGraphicPath, std::optional<int32_t> singleFrame, Position position, GameLevel* level);
         MissileGraphic(FASaveGame::GameLoader& loader);
 
-        virtual void save(FASaveGame::GameSaver& saver);
+        virtual void save(FASaveGame::GameSaver& saver) const;
         virtual void update();
 
         std::pair<FARender::FASpriteGroup*, int32_t> getCurrentFrame();

--- a/apps/freeablo/faworld/monster.cpp
+++ b/apps/freeablo/faworld/monster.cpp
@@ -50,7 +50,7 @@ namespace FAWorld
         mInitialised = true;
     }
 
-    void Monster::save(FASaveGame::GameSaver& saver)
+    void Monster::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("Monster", saver);
         Actor::save(saver);

--- a/apps/freeablo/faworld/monster.h
+++ b/apps/freeablo/faworld/monster.h
@@ -15,7 +15,7 @@ namespace FAWorld
         Monster(World& world, const DiabloExe::Monster& monsterStats);
         Monster(World& world, FASaveGame::GameLoader& loader);
 
-        void save(FASaveGame::GameSaver& saver) override;
+        void save(FASaveGame::GameSaver& saver) const override;
 
         virtual void calculateStats(LiveActorStats& stats, const ActorStats& actorStats) const override;
         void die() override;

--- a/apps/freeablo/faworld/movementhandler.cpp
+++ b/apps/freeablo/faworld/movementhandler.cpp
@@ -32,7 +32,7 @@ namespace FAWorld
         mSpeedTilesPerSecond.load(loader);
     }
 
-    void MovementHandler::save(FASaveGame::GameSaver& saver)
+    void MovementHandler::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("MovementHandler", saver);
 

--- a/apps/freeablo/faworld/movementhandler.h
+++ b/apps/freeablo/faworld/movementhandler.h
@@ -18,7 +18,7 @@ namespace FAWorld
     public:
         MovementHandler() = default;
         explicit MovementHandler(FASaveGame::GameLoader& loader);
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
 
         Misc::Point getDestination() const;
         void setDestination(Misc::Point dest, bool adjacent = false);

--- a/apps/freeablo/faworld/player.cpp
+++ b/apps/freeablo/faworld/player.cpp
@@ -314,7 +314,7 @@ namespace FAWorld
         mPlayerInitialised = true;
     }
 
-    void Player::save(FASaveGame::GameSaver& saver)
+    void Player::save(FASaveGame::GameSaver& saver) const
     {
         release_assert(mPlayerInitialised);
 

--- a/apps/freeablo/faworld/player.h
+++ b/apps/freeablo/faworld/player.h
@@ -16,7 +16,7 @@ namespace FAWorld
         Player(World& world, PlayerClass playerClass, const DiabloExe::CharacterStats& charStats);
         void initCommon();
         Player(World& world, FASaveGame::GameLoader& loader);
-        void save(FASaveGame::GameSaver& saver) override;
+        void save(FASaveGame::GameSaver& saver) const override;
 
         virtual ~Player();
         void updateSprites() override;

--- a/apps/freeablo/faworld/playerbehaviour.cpp
+++ b/apps/freeablo/faworld/playerbehaviour.cpp
@@ -27,7 +27,7 @@ namespace FAWorld
             hotkey = (SpellId)loader.load<int32_t>();
     }
 
-    void PlayerBehaviour::save(FASaveGame::GameSaver& saver)
+    void PlayerBehaviour::save(FASaveGame::GameSaver& saver) const
     {
         saver.save((int32_t)mActiveSpell);
 

--- a/apps/freeablo/faworld/playerbehaviour.h
+++ b/apps/freeablo/faworld/playerbehaviour.h
@@ -14,7 +14,7 @@ namespace FAWorld
         PlayerBehaviour(FASaveGame::GameLoader& loader);
         PlayerBehaviour() = default;
 
-        virtual void save(FASaveGame::GameSaver& saver) override;
+        virtual void save(FASaveGame::GameSaver& saver) const override;
         virtual void reAttach(Actor* actor) override;
         virtual void update() override;
 

--- a/apps/freeablo/faworld/position.cpp
+++ b/apps/freeablo/faworld/position.cpp
@@ -16,7 +16,7 @@ namespace FAWorld
         mFractionalPos = Vec2Fix(loader);
     }
 
-    void Position::save(FASaveGame::GameSaver& saver)
+    void Position::save(FASaveGame::GameSaver& saver) const
     {
         Serial::ScopedCategorySaver cat("Position", saver);
 

--- a/apps/freeablo/faworld/position.h
+++ b/apps/freeablo/faworld/position.h
@@ -18,7 +18,7 @@ namespace FAWorld
         explicit Position(Misc::Point point = Misc::Point::zero(), Misc::Direction direction = Misc::Direction(Misc::Direction8::south));
 
         Position(FASaveGame::GameLoader& loader);
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
 
         FixedPoint update(FixedPoint moveDistance);
         Misc::Point current() const; ///< where we are coming from

--- a/apps/freeablo/faworld/target.cpp
+++ b/apps/freeablo/faworld/target.cpp
@@ -71,7 +71,7 @@ namespace FAWorld
         }
     }
 
-    void Target::save(FASaveGame::GameSaver& saver)
+    void Target::save(FASaveGame::GameSaver& saver) const
     {
         saver.save(uint8_t(mType));
 

--- a/apps/freeablo/faworld/target.h
+++ b/apps/freeablo/faworld/target.h
@@ -42,7 +42,7 @@ namespace FAWorld
         Target() = default;
 
         void load(FASaveGame::GameLoader& loader);
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
 
         void clear();
 

--- a/apps/freeablo/faworld/world.cpp
+++ b/apps/freeablo/faworld/world.cpp
@@ -80,7 +80,7 @@ namespace FAWorld
         loader.currentlyLoadingWorld = nullptr;
     }
 
-    void World::save(FASaveGame::GameSaver& saver)
+    void World::save(FASaveGame::GameSaver& saver) const
     {
         mRng->save(saver);
         mLevelRng->save(saver);

--- a/apps/freeablo/faworld/world.h
+++ b/apps/freeablo/faworld/world.h
@@ -58,7 +58,7 @@ namespace FAWorld
     {
     public:
         World(const DiabloExe::DiabloExe& exe, uint32_t seed);
-        void save(FASaveGame::GameSaver& saver);
+        void save(FASaveGame::GameSaver& saver) const;
         void load(FASaveGame::GameLoader& loader);
         ~World();
 

--- a/components/level/dun.cpp
+++ b/components/level/dun.cpp
@@ -42,7 +42,7 @@ namespace Level
 
     Dun::Dun() {}
 
-    void Dun::save(Serial::Saver& saver)
+    void Dun::save(Serial::Saver& saver) const
     {
         Serial::ScopedCategorySaver cat("Dun", saver);
 

--- a/components/level/dun.h
+++ b/components/level/dun.h
@@ -22,7 +22,7 @@ namespace Level
         Dun();
         Dun(int32_t width, int32_t height);
 
-        void save(Serial::Saver& saver);
+        void save(Serial::Saver& saver) const;
 
         static Dun getTown(const Dun& sector1, const Dun& sector2, const Dun& sector3, const Dun& sector4);
 

--- a/components/level/level.cpp
+++ b/components/level/level.cpp
@@ -54,7 +54,7 @@ namespace Level
         mNext = loader.load<int32_t>();
     }
 
-    void Level::save(Serial::Saver& saver)
+    void Level::save(Serial::Saver& saver) const
     {
         Serial::ScopedCategorySaver cat("Level", saver);
 

--- a/components/level/level.h
+++ b/components/level/level.h
@@ -57,7 +57,7 @@ namespace Level
 
         Level() {}
 
-        void save(Serial::Saver& saver);
+        void save(Serial::Saver& saver) const;
 
         bool isDoor(const Misc::Point& point) const;
         bool activateDoor(const Misc::Point& point); /// @return If the door was activated

--- a/components/misc/maxcurrentitem.cpp
+++ b/components/misc/maxcurrentitem.cpp
@@ -11,7 +11,7 @@ namespace Misc
         current = loader.load<T>();
     }
 
-    template <typename T> void MaxCurrentItem<T>::save(Serial::Saver& saver)
+    template <typename T> void MaxCurrentItem<T>::save(Serial::Saver& saver) const
     {
         saver.save(max);
         saver.save(current);

--- a/components/misc/maxcurrentitem.h
+++ b/components/misc/maxcurrentitem.h
@@ -16,7 +16,7 @@ namespace Misc
         MaxCurrentItem() = default;
         explicit MaxCurrentItem(T max) : max(max), current(max) {}
         explicit MaxCurrentItem(Serial::Loader& loader);
-        void save(Serial::Saver& saver);
+        void save(Serial::Saver& saver) const;
 
         void add(T delta);
         void setMax(T max);

--- a/components/random/random.cpp
+++ b/components/random/random.cpp
@@ -20,7 +20,7 @@ namespace Random
         ss >> mRng;
     }
 
-    void RngMersenneTwister::save(Serial::Saver& saver)
+    void RngMersenneTwister::save(Serial::Saver& saver) const
     {
         std::stringstream ss;
         ss.imbue(std::locale::classic());

--- a/components/random/random.h
+++ b/components/random/random.h
@@ -25,7 +25,7 @@ namespace Random
         virtual int32_t randomInRange(int32_t min, int32_t max) = 0;
 
         virtual void load(Serial::Loader& loader) = 0;
-        virtual void save(Serial::Saver& saver) = 0;
+        virtual void save(Serial::Saver& saver) const = 0;
 
         template <typename T> T chooseOne(std::initializer_list<T> parameters)
         {
@@ -50,7 +50,7 @@ namespace Random
         RngMersenneTwister(const RngMersenneTwister&) = delete;
 
         virtual void load(Serial::Loader& loader) override;
-        virtual void save(Serial::Saver& saver) override;
+        virtual void save(Serial::Saver& saver) const override;
 
         virtual int32_t squaredRand(int32_t min, int32_t max) override;
         virtual int32_t randomInRange(int32_t min, int32_t max) override;
@@ -68,7 +68,7 @@ namespace Random
         virtual int32_t randomInRange(int32_t min, int32_t max) override { return min + (max - min) / 2; }
 
         virtual void load(Serial::Loader&) override { message_and_abort("cannot load DummRng"); }
-        virtual void save(Serial::Saver&) override { message_and_abort("cannot save DummRng"); }
+        virtual void save(Serial::Saver&) const override { message_and_abort("cannot save DummRng"); }
 
         static DummyRng instance;
 


### PR DESCRIPTION
This is a single commit appended on same branch as #475 (because of conflicts), the diff will make more sense after that is merged.
Just added `const` to all `save` methods I could find.
Adding the `save` method to a common base class (#478) requires that items/actors etc have the same `save` method signature, and it'd be a bit messy to include this in that PR.
Things that requiring saving should probably be implementing an `ISaveable` interface, but that can be done another day